### PR TITLE
Coveralls: Handle PR build result only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ matrix:
         - "8"
 
 after_script:
-- if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then npm run report-coveralls; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" &&
+    (( -n "$TRAVIS_PULL_REQUEST" && "$TRAVIS_PULL_REQUEST" != "false" ) || "$TRAVIS_BRANCH" == "master" ) ]]; then
+    npm run report-coveralls;
+  fi
 
 notifications:
   webhooks: https://coveralls.io/webhook

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"unit": "rimraf test/tmp && ava",
 		"unit-verbose": "rimraf test/tmp && cross-env UI5_LOG_LVL=verbose ava --verbose --serial",
 		"unit-watch": "rimraf test/tmp && ava --watch",
-		"unit-nyan": "npm run unit -- --tap | tnyan",
+		"unit-nyan": "rimraf test/tmp && ava --tap | tnyan",
 		"unit-inspect": "cross-env UI5_LOG_LVL=verbose node --inspect-brk node_modules/ava/profile.js",
 		"coverage": "nyc npm run unit",
 		"jsdoc": "npm run jsdoc-generate && opn jsdocs/index.html",


### PR DESCRIPTION
Ignore push builds. This should reduce the number of comments
Coveralls adds to PRs