### PR TITLE
[INTERNAL] Travis: Pin latest node version to 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js # don't install any environment
 
 node_js:
-- "node"
+- "11"
 
 os:
 - linux


### PR DESCRIPTION
The current version of a JSDoc dependency is not compatible with node 12.