### PR TITLE
[FIX] serve: Create SSL certificate in user homedir

### DIFF
--- a/lib/cli/commands/serve.js
+++ b/lib/cli/commands/serve.js
@@ -1,3 +1,6 @@
+const path = require("path");
+const os = require("os");
+
 // Serve
 const serve = {
 	command: "serve",
@@ -29,12 +32,12 @@ serve.builder = function(cli) {
 		})
 		.option("key", {
 			describe: "Path to the private key",
-			default: "$HOME/.ui5/server/server.key",
+			default: path.join(os.homedir(), ".ui5", "server", "server.key"),
 			type: "string"
 		})
 		.option("cert", {
 			describe: "Path to the certificate",
-			default: "$HOME/.ui5/server/server.crt",
+			default: path.join(os.homedir(), ".ui5", "server", "server.crt"),
 			type: "string"
 		})
 		.option("sap-csp-policies", {

--- a/test/lib/cli/commands/serve.js
+++ b/test/lib/cli/commands/serve.js
@@ -1,5 +1,7 @@
 const test = require("ava");
 const sinon = require("sinon");
+const path = require("path");
+const os = require("os");
 const normalizer = require("@ui5/project").normalizer;
 const serve = require("../../../../lib/cli/commands/serve");
 const ui5Server = require("@ui5/server");
@@ -7,9 +9,9 @@ const server = ui5Server.server;
 const mockRequire = require("mock-require");
 const defaultInitialHandlerArgs = Object.freeze({
 	accessRemoteConnections: false,
-	cert: "$HOME/.ui5/server/server.crt",
+	cert: path.join(os.homedir(), ".ui5", "server", "server.crt"),
 	h2: false,
-	key: "$HOME/.ui5/server/server.key",
+	key: path.join(os.homedir(), ".ui5", "server", "server.key"),
 	loglevel: "info",
 	t8r: "npm",
 	translator: "npm"
@@ -81,8 +83,8 @@ test.serial("ui5 serve --h2", async (t) => {
 	const injectedProjectTree = serverStub.getCall(0).args[0];
 	const injectedServerConfig = serverStub.getCall(0).args[1];
 
-	t.is(sslUtilStub.getCall(0).args[0], "$HOME/.ui5/server/server.key", "Load ssl key from default path");
-	t.is(sslUtilStub.getCall(0).args[1], "$HOME/.ui5/server/server.crt", "Load ssl cert from default path");
+	t.is(sslUtilStub.getCall(0).args[0], path.join(os.homedir(), ".ui5", "server", "server.key"), "Load ssl key from default path");
+	t.is(sslUtilStub.getCall(0).args[1], path.join(os.homedir(), ".ui5", "server", "server.crt"), "Load ssl cert from default path");
 	t.deepEqual(injectedProjectTree, projectTree, "Starting server with given project tree");
 	t.is(injectedServerConfig.port === 8443, true, "http2 default port was auto set");
 


### PR DESCRIPTION
The default certificate key/cert paths were using the $HOME variable
which was not replaced with the actual homedir of the user.
This caused creating a "$HOME" folder within the project which was not
intended.
Furthermore this can be dangerous in case someone wants to remove that
folder with `rm -rf`, as this might cause the homedir to be removed in
case no single quotes are used.

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [x] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/master/CONTRIBUTING.md#how-to-contribute) section 
- [x] [No merge commits](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#no-merge-commits)
- [x] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/master/docs/Guidelines.md#commit-message-style)
