### PR TITLE
[INTERNAL] Azure: Use Node v12 as latest in test matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,13 +16,13 @@ strategy:
       node_version: 10.x
     linux_node_latest:
       imageName: 'ubuntu-16.04'
-      node_version: 11.x
+      node_version: 12.x
     mac_node_latest:
       imageName: 'macos-10.13'
-      node_version: 11.x
+      node_version: 12.x
     windows_node_latest:
       imageName: 'vs2017-win2016'
-      node_version: 11.x
+      node_version: 12.x
 
 pool:
   vmImage: $(imageName)


### PR DESCRIPTION
Node 11 went end-of-life in June: https://github.com/nodejs/Release#end-of-life-releases