### PR TITLE
[FEATURE] ui5 build: Add --clean-dest option

### DIFF
--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -42,6 +42,11 @@ build.builder = function(cli) {
 			default: "./dist",
 			type: "string"
 		})
+		.option("clean-dest", {
+			describe: "If present, clean the destination directory before building",
+			default: false,
+			type: "boolean"
+		})
 		.option("dev-exclude-project", {
 			describe: "A list of specific projects to be excluded from dev mode (dev mode must be active for this to be effective)",
 			type: "array"
@@ -80,6 +85,7 @@ function handleBuild(argv) {
 		return builder.build({
 			tree: tree,
 			destPath: argv.dest,
+			cleanDest: argv["clean-dest"],
 			buildDependencies: argv.all,
 			dev: command === "dev",
 			selfContained: command === "self-contained",

--- a/test/lib/cli/commands/build.js
+++ b/test/lib/cli/commands/build.js
@@ -22,6 +22,7 @@ const defaultBuilderArgs = {
 	},
 	destPath: "./dist",
 	buildDependencies: undefined,
+	cleanDest: undefined,
 	dev: false,
 	selfContained: false,
 	jsdoc: false,


### PR DESCRIPTION
This exposes the UI5 Builders cleanDest parameter that was added
with https://github.com/SAP/ui5-builder/pull/306.

Usage: `ui5 build --clean-dest`
Description: If present, clean the destination directory before building
Default: `false`