### PR TITLE
[BREAKING] Require Node.js >= 10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ strategy:
     linux_node_10:
       imageName: 'ubuntu-18.04'
       node_version: 10.x
-    linux_node_latest:
+    linux_node_lts:
       imageName: 'ubuntu-18.04'
       node_version: 12.x
     linux_node_latest:
@@ -19,10 +19,10 @@ strategy:
       node_version: 13.x
     mac_node_latest:
       imageName: 'macOS-10.15'
-      node_version: 12.x
+      node_version: 13.x
     windows_node_latest:
       imageName: 'windows-2019'
-      node_version: 12.x
+      node_version: 13.x
 
 pool:
   vmImage: $(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,16 +9,16 @@ trigger:
 strategy:
   matrix:
     linux_node_10:
-      imageName: 'ubuntu-16.04'
+      imageName: 'ubuntu-18.04'
       node_version: 10.x
     linux_node_latest:
-      imageName: 'ubuntu-16.04'
+      imageName: 'ubuntu-18.04'
       node_version: 12.x
     mac_node_latest:
-      imageName: 'macos-10.13'
+      imageName: 'macOS-10.15'
       node_version: 12.x
     windows_node_latest:
-      imageName: 'vs2017-win2016'
+      imageName: 'windows-2019'
       node_version: 12.x
 
 pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,9 @@ strategy:
     linux_node_latest:
       imageName: 'ubuntu-18.04'
       node_version: 12.x
+    linux_node_latest:
+      imageName: 'ubuntu-18.04'
+      node_version: 13.x
     mac_node_latest:
       imageName: 'macOS-10.15'
       node_version: 12.x

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,9 +8,6 @@ trigger:
 
 strategy:
   matrix:
-    linux_node_8:
-      imageName: 'ubuntu-16.04'
-      node_version: 8.x
     linux_node_10:
       imageName: 'ubuntu-16.04'
       node_version: 10.x

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"main": "index.js",
 	"engines": {
-		"node": ">= 8.5",
+		"node": ">= 10",
 		"npm": ">= 5"
 	},
 	"scripts": {


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js releases has been dropped.
Only Node.js v10 or higher is supported.