### PR TITLE
[INTERNAL] package.json: Move postversion git push to prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"jsdoc-watch": "npm run jsdoc && chokidar \"./lib/**/*.js\" -c \"npm run jsdoc-generate\"",
 		"preversion": "npm test",
 		"version": "git-chglog --next-tag v$npm_package_version -o CHANGELOG.md && git add CHANGELOG.md",
-		"postversion": "git push --follow-tags",
+		"prepublishOnly": "git push --follow-tags",
 		"release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version",
 		"report-coveralls": "nyc report --reporter=text-lcov | COVERALLS_PARALLEL=true coveralls"
 	},


### PR DESCRIPTION
This allows our CI to do some final validation between "npm version" and
"npm publish". I.e. validating the reduced npm-shrinkwrap-json that is
created after "npm version" created the release commit".