### PR TITLE
[FIX] ui5 use/add: Fix updating ui5.yaml file

### DIFF
--- a/lib/framework/updateYaml.js
+++ b/lib/framework/updateYaml.js
@@ -135,7 +135,7 @@ function formatValue(value, indent) {
 		const string = safeDump(value);
 		const arr = string.split("\n");
 		arr.pop();
-		return "\n" + indentString + arr.join("\n" + indentString);
+		return "\n" + indentString + arr.join("\n" + indentString) + "\n";
 	}
 }
 
@@ -174,10 +174,14 @@ module.exports = async function({project, data}) {
 			const firstSiblingPosition = getPosition(parentData[siblings[0]]);
 			indent = firstSiblingPosition.start.column - 1;
 		}
+		let value = `${" ".repeat(indent)}${entryPath[entryPath.length - 1]}:${formatValue(newValue, indent + 2)}`;
+		if (!value.endsWith("\n")) {
+			value += "\n";
+		}
 		changes.push({
 			type: "insert",
 			parentPosition,
-			value: `${" ".repeat(indent)}${entryPath[entryPath.length - 1]}:${formatValue(newValue, indent + 2)}\n`
+			value
 		});
 	}
 
@@ -187,7 +191,7 @@ module.exports = async function({project, data}) {
 		const indent = position.start.column - 1;
 		changes.push({
 			type: "update",
-			position: getPositionFromPath(positionData, entryPath),
+			position,
 			value: `${entryPath[entryPath.length - 1]}:${formatValue(newValue, indent + 2)}`
 		});
 	}

--- a/test/lib/framework/updateYaml.js
+++ b/test/lib/framework/updateYaml.js
@@ -329,6 +329,96 @@ framework:
 `, "writeFile should be called with expected content");
 });
 
+test.serial("Should add new array to document with content below", async (t) => {
+	t.context.fsReadFileStub.yieldsAsync(null, `
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  version: "1.76.0"
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8`);
+
+	await updateYaml({
+		project: {
+			path: "my-project",
+			metadata: {"name": "my-project"}
+		},
+		data: {
+			framework: {
+				libraries: [
+					{name: "sap.ui.core"},
+					{name: "sap.m"}
+				]
+			}
+		}
+	});
+
+	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
+	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
+		"writeFile should be called with expected path");
+	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  version: "1.76.0"
+  libraries:
+    - name: sap.ui.core
+    - name: sap.m
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
+`, "writeFile should be called with expected content");
+});
+
+test.serial("Should add new array to document with content separated by empty line below", async (t) => {
+	t.context.fsReadFileStub.yieldsAsync(null, `
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  version: "1.76.0"
+
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8`);
+
+	await updateYaml({
+		project: {
+			path: "my-project",
+			metadata: {"name": "my-project"}
+		},
+		data: {
+			framework: {
+				libraries: [
+					{name: "sap.ui.core"},
+					{name: "sap.m"}
+				]
+			}
+		}
+	});
+
+	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
+	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
+		"writeFile should be called with expected path");
+	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  version: "1.76.0"
+  libraries:
+    - name: sap.ui.core
+    - name: sap.m
+
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
+`, "writeFile should be called with expected content");
+});
+
 test.serial("Should add new array element to document", async (t) => {
 	t.context.fsReadFileStub.yieldsAsync(null, `
 metadata:
@@ -410,6 +500,106 @@ framework:
     - name: sap.ui.core
     - name: sap.m
     - name: sap.ui.layout
+`, "writeFile should be called with expected content");
+});
+
+test.serial("Should add new array elements to document with content below", async (t) => {
+	t.context.fsReadFileStub.yieldsAsync(null, `
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  version: "1.76.0"
+  libraries:
+    - name: sap.ui.core
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
+`);
+
+	await updateYaml({
+		project: {
+			path: "my-project",
+			metadata: {"name": "my-project"}
+		},
+		data: {
+			framework: {
+				libraries: [
+					{name: "sap.ui.core"},
+					{name: "sap.m"},
+					{name: "sap.ui.layout"}
+				]
+			}
+		}
+	});
+
+	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
+	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
+		"writeFile should be called with expected path");
+	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  version: "1.76.0"
+  libraries:
+    - name: sap.ui.core
+    - name: sap.m
+    - name: sap.ui.layout
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
+`, "writeFile should be called with expected content");
+});
+
+
+test.serial("Should add new array elements to document with content separated by empty line below", async (t) => {
+	t.context.fsReadFileStub.yieldsAsync(null, `
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  version: "1.76.0"
+  libraries:
+    - name: sap.ui.core
+
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
+`);
+
+	await updateYaml({
+		project: {
+			path: "my-project",
+			metadata: {"name": "my-project"}
+		},
+		data: {
+			framework: {
+				libraries: [
+					{name: "sap.ui.core"},
+					{name: "sap.m"},
+					{name: "sap.ui.layout"}
+				]
+			}
+		}
+	});
+
+	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
+	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
+		"writeFile should be called with expected path");
+	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  version: "1.76.0"
+  libraries:
+    - name: sap.ui.core
+    - name: sap.m
+    - name: sap.ui.layout
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
 `, "writeFile should be called with expected content");
 });
 


### PR DESCRIPTION
In some cases the use/add command has failed to update the ui5.yaml
file, e.g. when some configuration is after the "framework" section.