### PR TITLE
[FEATURE] ui5 serve: Add serve-csp-reports option

### DIFF
--- a/lib/cli/commands/serve.js
+++ b/lib/cli/commands/serve.js
@@ -50,9 +50,10 @@ serve.builder = function(cli) {
 			default: false,
 			type: "boolean"
 		})
-		.option("csp-report-path", {
-			describe: "FilePath where csp-reports are written to",
-			type: "string"
+		.option("serve-csp-reports", {
+			describe: "collects and serves csp-reports upon request to '/.ui5/csp/csp-reports.json'",
+			default: false,
+			type: "boolean"
 		})
 		.option("framework-version", {
 			describe: "Overrides the framework version defined by the project",
@@ -113,7 +114,7 @@ serve.handler = async function(argv) {
 		cert: argv.h2 ? argv.cert : undefined,
 		key: argv.h2 ? argv.key : undefined,
 		sendSAPTargetCSP: !!argv.sapCspPolicies,
-		cspReportPath: argv.cspReportPath
+		serveCSPReports: !!argv.serveCspReports
 	};
 
 	if (serverConfig.h2) {

--- a/lib/cli/commands/serve.js
+++ b/lib/cli/commands/serve.js
@@ -50,7 +50,7 @@ serve.builder = function(cli) {
 			default: false,
 			type: "boolean"
 		})
-		.option("cspReportPath", {
+		.option("csp-report-path", {
 			describe: "FilePath where csp-reports are written to",
 			type: "string"
 		})

--- a/lib/cli/commands/serve.js
+++ b/lib/cli/commands/serve.js
@@ -50,6 +50,10 @@ serve.builder = function(cli) {
 			default: false,
 			type: "boolean"
 		})
+		.option("cspReportPath", {
+			describe: "FilePath where csp-reports are written to",
+			type: "string"
+		})
 		.option("framework-version", {
 			describe: "Overrides the framework version defined by the project",
 			type: "string"
@@ -108,7 +112,8 @@ serve.handler = async function(argv) {
 		acceptRemoteConnections: !!argv.acceptRemoteConnections,
 		cert: argv.h2 ? argv.cert : undefined,
 		key: argv.h2 ? argv.key : undefined,
-		sendSAPTargetCSP: !!argv.sapCspPolicies
+		sendSAPTargetCSP: !!argv.sapCspPolicies,
+		cspReportPath: argv.cspReportPath
 	};
 
 	if (serverConfig.h2) {

--- a/lib/cli/commands/serve.js
+++ b/lib/cli/commands/serve.js
@@ -51,7 +51,7 @@ serve.builder = function(cli) {
 			type: "boolean"
 		})
 		.option("serve-csp-reports", {
-			describe: "collects and serves csp-reports upon request to '/.ui5/csp/csp-reports.json'",
+			describe: "Collects and serves CSP reports upon request to '/.ui5/csp/csp-reports.json'",
 			default: false,
 			type: "boolean"
 		})

--- a/test/lib/cli/commands/serve.js
+++ b/test/lib/cli/commands/serve.js
@@ -348,7 +348,7 @@ test.serial("ui5 serve: --framework-version", async (t) => {
 	}]);
 });
 
-test.serial("ui5 serve: --serve-csp-reports=true", async (t) => {
+test.serial("ui5 serve --serve-csp-reports", async (t) => {
 	normalizerStub.resolves(projectTree);
 	serverStub.resolves({h2: false, port: 8080});
 

--- a/test/lib/cli/commands/serve.js
+++ b/test/lib/cli/commands/serve.js
@@ -61,7 +61,8 @@ test.serial("ui5 serve: default", async (t) => {
 		port: 8080,
 		cert: undefined,
 		key: undefined,
-		sendSAPTargetCSP: false
+		sendSAPTargetCSP: false,
+		cspReportPath: undefined
 	}, "Starting server with specific server config");
 });
 
@@ -98,7 +99,8 @@ test.serial("ui5 serve --h2", async (t) => {
 		port: 8443,
 		key: "randombyte-likes-ponies-key",
 		cert: "randombyte-likes-ponies-cert",
-		sendSAPTargetCSP: false
+		sendSAPTargetCSP: false,
+		cspReportPath: undefined
 	}, "Starting server with specific server config");
 });
 
@@ -170,7 +172,8 @@ test.serial("ui5 serve --key --cert", async (t) => {
 		port: 8443,
 		key: "ponies-loaded-from-custompath-key",
 		cert: "ponies-loaded-from-custompath-crt",
-		sendSAPTargetCSP: false
+		sendSAPTargetCSP: false,
+		cspReportPath: undefined
 	}, "Starting server with specific server config");
 });
 
@@ -215,7 +218,8 @@ test.serial("ui5 serve --sap-csp-policies", async (t) => {
 		port: 8080,
 		cert: undefined,
 		key: undefined,
-		sendSAPTargetCSP: true
+		sendSAPTargetCSP: true,
+		cspReportPath: undefined
 	}, "Starting server with specific server config");
 });
 

--- a/test/lib/cli/commands/serve.js
+++ b/test/lib/cli/commands/serve.js
@@ -62,7 +62,7 @@ test.serial("ui5 serve: default", async (t) => {
 		cert: undefined,
 		key: undefined,
 		sendSAPTargetCSP: false,
-		cspReportPath: undefined
+		serveCSPReports: false
 	}, "Starting server with specific server config");
 });
 
@@ -100,7 +100,7 @@ test.serial("ui5 serve --h2", async (t) => {
 		key: "randombyte-likes-ponies-key",
 		cert: "randombyte-likes-ponies-cert",
 		sendSAPTargetCSP: false,
-		cspReportPath: undefined
+		serveCSPReports: false
 	}, "Starting server with specific server config");
 });
 
@@ -173,7 +173,7 @@ test.serial("ui5 serve --key --cert", async (t) => {
 		key: "ponies-loaded-from-custompath-key",
 		cert: "ponies-loaded-from-custompath-crt",
 		sendSAPTargetCSP: false,
-		cspReportPath: undefined
+		serveCSPReports: false
 	}, "Starting server with specific server config");
 });
 
@@ -219,7 +219,7 @@ test.serial("ui5 serve --sap-csp-policies", async (t) => {
 		cert: undefined,
 		key: undefined,
 		sendSAPTargetCSP: true,
-		cspReportPath: undefined
+		serveCSPReports: false
 	}, "Starting server with specific server config");
 });
 
@@ -348,13 +348,13 @@ test.serial("ui5 serve: --framework-version", async (t) => {
 	}]);
 });
 
-test.serial("ui5 serve: --csp-report-path=pony", async (t) => {
+test.serial("ui5 serve: --serve-csp-reports=true", async (t) => {
 	normalizerStub.resolves(projectTree);
 	serverStub.resolves({h2: false, port: 8080});
 
 	// loads project tree
 	const pPrepareServerConfig = await serve.handler(
-		Object.assign({}, defaultInitialHandlerArgs, {cspReportPath: "pony"})
+		Object.assign({}, defaultInitialHandlerArgs, {serveCspReports: true})
 	);
 	// preprocess project config, skipping cert load
 	const pServeServer = await pPrepareServerConfig;
@@ -364,5 +364,5 @@ test.serial("ui5 serve: --csp-report-path=pony", async (t) => {
 	const injectedServerConfig = serverStub.getCall(0).args[1];
 
 	t.is(normalizerStub.called, true);
-	t.deepEqual(injectedServerConfig.cspReportPath, "pony", "cspReportPath value set");
+	t.deepEqual(injectedServerConfig.serveCSPReports, true, "serveCSPReports value set");
 });

--- a/test/lib/cli/commands/serve.js
+++ b/test/lib/cli/commands/serve.js
@@ -343,3 +343,22 @@ test.serial("ui5 serve: --framework-version", async (t) => {
 		}
 	}]);
 });
+
+test.serial("ui5 serve: --csp-report-path=pony", async (t) => {
+	normalizerStub.resolves(projectTree);
+	serverStub.resolves({h2: false, port: 8080});
+
+	// loads project tree
+	const pPrepareServerConfig = await serve.handler(
+		Object.assign({}, defaultInitialHandlerArgs, {cspReportPath: "pony"})
+	);
+	// preprocess project config, skipping cert load
+	const pServeServer = await pPrepareServerConfig;
+	// serve server using config
+	await pServeServer;
+
+	const injectedServerConfig = serverStub.getCall(0).args[1];
+
+	t.is(normalizerStub.called, true);
+	t.deepEqual(injectedServerConfig.cspReportPath, "pony", "cspReportPath value set");
+});


### PR DESCRIPTION
Add option to use csp-report-path to create csp reports for server.

See: SAP/ui5-server/pull/323

Sample call
```bash
ui5 serve --serve-csp-reports
```
