### PR TITLE
[INTERNAL] ui5 serve: Log warning when accepting remote connections

### DIFF
--- a/lib/cli/commands/serve.js
+++ b/lib/cli/commands/serve.js
@@ -131,6 +131,20 @@ serve.handler = async function(argv) {
 
 	const protocol = h2 ? "https" : "http";
 	let browserUrl = protocol + "://localhost:" + actualPort;
+	if (argv.acceptRemoteConnections) {
+		const chalk = require("chalk");
+		console.log("");
+		console.log(chalk.bold("⚠️  This server is accepting connections from all hosts on your network"));
+		console.log(chalk.dim.underline("Please Note:"));
+		console.log(chalk.bold.dim(
+			"* This server is intended for development purposes only. Do not use in production!"));
+		console.log(chalk.dim(
+			"* Vulnerable (custom-) middleware can pose a threat to your system when exposed to the network"));
+		console.log(chalk.dim(
+			"* The use of proxy-middleware with preconfigured credentials might enable unauthorized access " +
+			"to a target system for third parties on your network"));
+		console.log("");
+	}
 	console.log("Server started");
 	console.log("URL: " + browserUrl);
 

--- a/lib/cli/commands/serve.js
+++ b/lib/cli/commands/serve.js
@@ -137,9 +137,9 @@ serve.handler = async function(argv) {
 		console.log(chalk.bold("⚠️  This server is accepting connections from all hosts on your network"));
 		console.log(chalk.dim.underline("Please Note:"));
 		console.log(chalk.bold.dim(
-			"* This server is intended for development purposes only. Do not use in production!"));
+			"* This server is intended for development purposes only. Do not use it in production."));
 		console.log(chalk.dim(
-			"* Vulnerable (custom-) middleware can pose a threat to your system when exposed to the network"));
+			"* Vulnerable (custom-)middleware can pose a threat to your system when exposed to the network"));
 		console.log(chalk.dim(
 			"* The use of proxy-middleware with preconfigured credentials might enable unauthorized access " +
 			"to a target system for third parties on your network"));


### PR DESCRIPTION
Since the use of the --accept-remote-connections parameter might
indicate the intent to use the server in a productive environment, we
warn users not to do that.

And even in development environments, exposing the server to the network
might be a security risk for the system. Therefore we also warn on some
of those aspects.

Resolves: https://github.com/SAP/ui5-tooling/issues/326