### PR TITLE
[FIX] Allow Node.js pre-release versions

### DIFF
--- a/bin/ui5.js
+++ b/bin/ui5.js
@@ -33,7 +33,8 @@ if (
 		console.log("");
 		console.log("=> Please note that an unstable version might cause unexpected");
 		console.log("   behavior. For productive use please consider using a stable");
-		console.log("   version of Node.js!");
+		console.log("   version of Node.js! For the release policy of Node.js, see");
+		console.log("   https://nodejs.org/en/about/releases");
 		console.log("=====================================================================");
 	}
 	// Timeout is required to log info when importing from local installation

--- a/bin/ui5.js
+++ b/bin/ui5.js
@@ -14,7 +14,10 @@ try {
 }
 var nodeVersion = process.version;
 /* eslint-enable no-var */
-if (pkg.engines && pkg.engines.node && (!semver || !semver.satisfies(nodeVersion, pkg.engines.node))) {
+if (
+	pkg.engines && pkg.engines.node &&
+	(!semver || !semver.satisfies(nodeVersion, pkg.engines.node, {includePrerelease: true}))
+) {
 	console.log("==================== UNSUPPORTED NODE.JS VERSION ====================");
 	console.log("You are using an unsupported version of Node.js");
 	console.log("Detected version " + nodeVersion + " but " + pkg.name + " requires " + pkg.engines.node);
@@ -23,6 +26,16 @@ if (pkg.engines && pkg.engines.node && (!semver || !semver.satisfies(nodeVersion
 	console.log("=====================================================================");
 	process.exit(1);
 } else {
+	if (semver && semver.prerelease(nodeVersion)) {
+		console.log("====================== UNSTABLE NODE.JS VERSION =====================");
+		console.log("You are using an unstable version of Node.js");
+		console.log("Detected Node.js version " + nodeVersion);
+		console.log("");
+		console.log("=> Please note that an unstable version might cause unexpected");
+		console.log("   behavior. For productive use please consider using a stable");
+		console.log("   version of Node.js!");
+		console.log("=====================================================================");
+	}
 	// Timeout is required to log info when importing from local installation
 	setTimeout(() => {
 		if (!process.env.UI5_CLI_NO_LOCAL) {

--- a/test/bin/ui5.js
+++ b/test/bin/ui5.js
@@ -110,8 +110,7 @@ test.serial.cb("ui5 logs warning when using pre-release Node.js version", (t) =>
 	const importLocalStub = sinon.stub().returns(true);
 	mock("import-local", importLocalStub);
 
-	const sandbox = sinon.createSandbox();
-	sandbox.stub(process, "version").value("v17.0.0-v8-canary202108258414d1aed8");
+	sinon.stub(process, "version").value("v17.0.0-v8-canary202108258414d1aed8");
 
 	mock.reRequire("../../bin/ui5");
 
@@ -142,8 +141,6 @@ test.serial.cb("ui5 logs warning when using pre-release Node.js version", (t) =>
 			path.resolve(__dirname, "..", "..", "bin", "ui5.js")
 		], "import-local should be called with bin/ui5.js filename");
 
-		consoleLogStub.restore();
-		sandbox.restore();
 		t.end();
 	}, 0);
 });

--- a/test/bin/ui5.js
+++ b/test/bin/ui5.js
@@ -116,7 +116,7 @@ test.serial.cb("ui5 logs warning when using pre-release Node.js version", (t) =>
 	mock.reRequire("../../bin/ui5");
 
 	setTimeout(() => {
-		t.is(consoleLogStub.callCount, 8, "console.log should be called 8 times");
+		t.is(consoleLogStub.callCount, 9, "console.log should be called 8 times");
 
 		t.is(consoleLogStub.getCall(0).args[0],
 			"====================== UNSTABLE NODE.JS VERSION =====================");
@@ -131,8 +131,10 @@ test.serial.cb("ui5 logs warning when using pre-release Node.js version", (t) =>
 		t.is(consoleLogStub.getCall(5).args[0],
 			"   behavior. For productive use please consider using a stable");
 		t.is(consoleLogStub.getCall(6).args[0],
-			"   version of Node.js!");
+			"   version of Node.js! For the release policy of Node.js, see");
 		t.is(consoleLogStub.getCall(7).args[0],
+			"   https://nodejs.org/en/about/releases");
+		t.is(consoleLogStub.getCall(8).args[0],
 			"=====================================================================");
 
 		t.is(importLocalStub.callCount, 1, "import-local should be called once");

--- a/test/bin/ui5.js
+++ b/test/bin/ui5.js
@@ -103,3 +103,45 @@ test.serial.cb("ui5 imports local installation when found (/w --verbose)", (t) =
 		t.end();
 	}, 0);
 });
+
+test.serial.cb("ui5 logs warning when using pre-release Node.js version", (t) => {
+	const consoleLogStub = sinon.stub(console, "log");
+
+	const importLocalStub = sinon.stub().returns(true);
+	mock("import-local", importLocalStub);
+
+	const sandbox = sinon.createSandbox();
+	sandbox.stub(process, "version").value("v17.0.0-v8-canary202108258414d1aed8");
+
+	mock.reRequire("../../bin/ui5");
+
+	setTimeout(() => {
+		t.is(consoleLogStub.callCount, 8, "console.log should be called 8 times");
+
+		t.is(consoleLogStub.getCall(0).args[0],
+			"====================== UNSTABLE NODE.JS VERSION =====================");
+		t.is(consoleLogStub.getCall(1).args[0],
+			"You are using an unstable version of Node.js");
+		t.is(consoleLogStub.getCall(2).args[0],
+			"Detected Node.js version v17.0.0-v8-canary202108258414d1aed8");
+		t.is(consoleLogStub.getCall(3).args[0],
+			"");
+		t.is(consoleLogStub.getCall(4).args[0],
+			"=> Please note that an unstable version might cause unexpected");
+		t.is(consoleLogStub.getCall(5).args[0],
+			"   behavior. For productive use please consider using a stable");
+		t.is(consoleLogStub.getCall(6).args[0],
+			"   version of Node.js!");
+		t.is(consoleLogStub.getCall(7).args[0],
+			"=====================================================================");
+
+		t.is(importLocalStub.callCount, 1, "import-local should be called once");
+		t.deepEqual(importLocalStub.getCall(0).args, [
+			path.resolve(__dirname, "..", "..", "bin", "ui5.js")
+		], "import-local should be called with bin/ui5.js filename");
+
+		consoleLogStub.restore();
+		sandbox.restore();
+		t.end();
+	}, 0);
+});


### PR DESCRIPTION
Support to use the UI5 Tooling with a Node.js pre-release
version. In case of using a pre-release version a warning
will be reported that for productive use only stable versions
should be used.

Fixes: https://github.com/SAP/ui5-tooling/issues/550