### PR TITLE
[INTERNAL] npm release: Add missing CHANGELOG file

### DIFF
--- a/.chglog/consolidate-changelogs.js
+++ b/.chglog/consolidate-changelogs.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 
 function handleDependencyBump(line) {
 	line = line.replace("[@ui5](https://github.com/ui5)", "@ui5");
-	const moduleMatch = line.match(/Bump (@ui5\/[^\s]+).*to ([0-9.]+)/);
+	const moduleMatch = line.match(/Bump (@ui5\/[^\s]+).*to ([^ ]+)/);
 	if (moduleMatch) {
 		const [, moduleName, moduleVersion] = moduleMatch;
 		const moduleDir = path.dirname(require.resolve(moduleName));

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"depcheck": "depcheck --ignores docdash,@ui5/fs"
 	},
 	"files": [
+		"CHANGELOG.md",
 		"CONTRIBUTING.md",
 		"index.js",
 		"jsdoc.json",


### PR DESCRIPTION
The CLI needs the changelog files of all modules to create a
consolidated changelog.

Since npm v7 the CHANGELOG file is not always published anymore.
See: https://github.com/npm/npm-packlist/pull/61
