### PR TITLE
[INTERNAL] use eslint-plugin-ava and cleanup test-suite

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,10 @@ module.exports = {
 		"node": true,
 		"es2021": true
 	},
-	"extends": ["eslint:recommended", "google"],
+	"extends": ["eslint:recommended", "plugin:ava/recommended", "google"],
 	"plugins": [
-		"jsdoc"
+		"jsdoc",
+		"ava"
 	],
 	"rules": {
 		"indent": [
@@ -65,7 +66,10 @@ module.exports = {
 		"jsdoc/require-returns": 0,
 		"jsdoc/require-returns-description": 0,
 		"jsdoc/require-returns-type": 2,
-		"jsdoc/valid-types": 0
+		"jsdoc/valid-types": 0,
+		// ava/assertion-arguments reports concatenated strings in a assertion message as an issue
+		// See: https://github.com/avajs/eslint-plugin-ava/issues/332
+		"ava/assertion-arguments": 0
 	},
 	"settings": {
 		"jsdoc": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -35,6 +35,7 @@
 				"docdash": "^1.2.0",
 				"eslint": "^8.7.0",
 				"eslint-config-google": "^0.14.0",
+				"eslint-plugin-ava": "^13.0.2",
 				"eslint-plugin-jsdoc": "^37.6.3",
 				"execa": "^5.1.1",
 				"jsdoc": "^3.6.7",
@@ -3150,6 +3151,18 @@
 				"once": "^1.4.0"
 			}
 		},
+		"node_modules/enhance-visitors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+			"integrity": "sha512-+29eJLiUixTEDRaZ35Vu8jP3gPLNcQQkQkOQjLp2X+6cZGGPDD/uasbFzvLsJKnGZnvmyZ0srxudwOtskHeIDA==",
+			"dev": true,
+			"dependencies": {
+				"lodash": "^4.13.1"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -3395,6 +3408,119 @@
 				"eslint": ">=5.16.0"
 			}
 		},
+		"node_modules/eslint-plugin-ava": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"dev": true,
+			"dependencies": {
+				"enhance-visitors": "^1.0.0",
+				"eslint-utils": "^3.0.0",
+				"espree": "^9.0.0",
+				"espurify": "^2.1.1",
+				"import-modules": "^2.1.0",
+				"micro-spelling-correcter": "^1.1.1",
+				"pkg-dir": "^5.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.22 <13 || >=14.17 <15 || >=16.4"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.22.0"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/pkg-dir": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/eslint-plugin-jsdoc": {
 			"version": "37.9.7",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
@@ -3538,6 +3664,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/espurify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
+			"integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
+			"dev": true
 		},
 		"node_modules/esquery": {
 			"version": "1.4.0",
@@ -4716,6 +4848,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/import-modules": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+			"integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5780,6 +5924,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/micro-spelling-correcter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+			"integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
+			"dev": true
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.5",
@@ -9593,6 +9743,18 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/yesno/-/yesno-0.3.1.tgz",
 			"integrity": "sha512-7RbCXegyu6DykWPWU0YEtW8gFJH8KBL2d5l2fqB0XpkH0Y9rk59YSSWpzEv7yNJBGAouPc67h3kkq0CZkpBdFw=="
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		}
 	},
 	"dependencies": {
@@ -12035,6 +12197,15 @@
 				"once": "^1.4.0"
 			}
 		},
+		"enhance-visitors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+			"integrity": "sha512-+29eJLiUixTEDRaZ35Vu8jP3gPLNcQQkQkOQjLp2X+6cZGGPDD/uasbFzvLsJKnGZnvmyZ0srxudwOtskHeIDA==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.13.1"
+			}
+		},
 		"entities": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -12266,6 +12437,82 @@
 			"dev": true,
 			"requires": {}
 		},
+		"eslint-plugin-ava": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"dev": true,
+			"requires": {
+				"enhance-visitors": "^1.0.0",
+				"eslint-utils": "^3.0.0",
+				"espree": "^9.0.0",
+				"espurify": "^2.1.1",
+				"import-modules": "^2.1.0",
+				"micro-spelling-correcter": "^1.1.1",
+				"pkg-dir": "^5.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+					"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
+			}
+		},
 		"eslint-plugin-jsdoc": {
 			"version": "37.9.7",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
@@ -12336,6 +12583,12 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"espurify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
+			"integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
 			"dev": true
 		},
 		"esquery": {
@@ -13265,6 +13518,12 @@
 				"resolve-cwd": "^3.0.0"
 			}
 		},
+		"import-modules": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+			"integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+			"dev": true
+		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -14080,6 +14339,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
 			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+		},
+		"micro-spelling-correcter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+			"integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "4.0.5",
@@ -17058,6 +17323,12 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/yesno/-/yesno-0.3.1.tgz",
 			"integrity": "sha512-7RbCXegyu6DykWPWU0YEtW8gFJH8KBL2d5l2fqB0XpkH0Y9rk59YSSWpzEv7yNJBGAouPc67h3kkq0CZkpBdFw=="
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
 		"eslint": "^8.7.0",
 		"eslint-config-google": "^0.14.0",
 		"eslint-plugin-jsdoc": "^37.6.3",
+		"eslint-plugin-ava": "^13.0.2",
 		"execa": "^5.1.1",
 		"jsdoc": "^3.6.7",
 		"mock-require": "^3.0.3",

--- a/test/bin/ui5.js
+++ b/test/bin/ui5.js
@@ -1,3 +1,7 @@
+/* eslint-disable ava/no-unknown-modifiers */
+/* Test modifier `cb` was deprecated with ava version
+3 and removed with ava version 4. Therefore, tests using `cb` has to be rewritten, when upgrade to ava version 4 */
+
 const test = require("ava");
 const sinon = require("sinon");
 const mock = require("mock-require");

--- a/test/lib/cli/commands/base.js
+++ b/test/lib/cli/commands/base.js
@@ -1,3 +1,7 @@
+/* eslint-disable ava/no-unknown-modifiers */
+/* Test modifier `cb` was deprecated with ava version
+3 and removed with ava version 4. Therefore, tests using `cb` has to be rewritten, when upgrade to ava version 4 */
+
 const test = require("ava");
 const path = require("path");
 const execa = require("execa");
@@ -29,12 +33,12 @@ test.serial("Yargs error handling", async (t) => {
 	const err = await t.throwsAsync(ui5(["invalidcomands"]));
 
 	const stdoutLines = err.stdout.split("\n");
-	t.deepEqual(stdoutLines[0], "Command Failed:", "Correct first log line");
+	t.is(stdoutLines[0], "Command Failed:", "Correct first log line");
 	// Error message itself originates from yargs and is therefore not asserted
-	t.deepEqual(stdoutLines[stdoutLines.length - 1], `See 'ui5 --help' or 'ui5 build --help' for help`,
+	t.is(stdoutLines[stdoutLines.length - 1], `See 'ui5 --help' or 'ui5 build --help' for help`,
 		"Correct last log line");
 
-	t.deepEqual(err.exitCode, 1, "Process was exited with code 1");
+	t.is(err.exitCode, 1, "Process was exited with code 1");
 });
 
 test.serial("Exception error handling", async (t) => {
@@ -45,14 +49,14 @@ test.serial("Exception error handling", async (t) => {
 	}));
 
 	const stdoutLines = err.stdout.split("\n");
-	t.deepEqual(stdoutLines[1], "⚠️  Process Failed With Error", "Correct error log");
-	t.deepEqual(stdoutLines[3], "Error Message:", "Correct error log");
-	t.deepEqual(stdoutLines[4], "Initialization not possible: ui5.yaml already exists", "Correct error log");
-	t.deepEqual(stdoutLines[stdoutLines.length - 1],
+	t.is(stdoutLines[1], "⚠️  Process Failed With Error", "Correct error log");
+	t.is(stdoutLines[3], "Error Message:", "Correct error log");
+	t.is(stdoutLines[4], "Initialization not possible: ui5.yaml already exists", "Correct error log");
+	t.is(stdoutLines[stdoutLines.length - 1],
 		"For details, execute the same command again with an additional '--verbose' parameter",
 		"Correct last log line");
 
-	t.deepEqual(err.exitCode, 1, "Process was exited with code 1");
+	t.is(err.exitCode, 1, "Process was exited with code 1");
 });
 
 test.serial("Exception error handling with verbose logging", async (t) => {
@@ -63,18 +67,18 @@ test.serial("Exception error handling with verbose logging", async (t) => {
 	}));
 
 	const stdoutLines = err.stdout.split("\n");
-	t.deepEqual(stdoutLines[1], "⚠️  Process Failed With Error", "Correct error log");
-	t.deepEqual(stdoutLines[3], "Error Message:", "Correct error log");
-	t.deepEqual(stdoutLines[4], "Initialization not possible: ui5.yaml already exists", "Correct error log");
-	t.deepEqual(stdoutLines[6], "Stack Trace:", "Correct error log");
-	t.deepEqual(stdoutLines[7], "Error: Initialization not possible: ui5.yaml already exists", "Correct error log");
+	t.is(stdoutLines[1], "⚠️  Process Failed With Error", "Correct error log");
+	t.is(stdoutLines[3], "Error Message:", "Correct error log");
+	t.is(stdoutLines[4], "Initialization not possible: ui5.yaml already exists", "Correct error log");
+	t.is(stdoutLines[6], "Stack Trace:", "Correct error log");
+	t.is(stdoutLines[7], "Error: Initialization not possible: ui5.yaml already exists", "Correct error log");
 
 	t.deepEqual(stdoutLines[stdoutLines.length - 1],
 		"If you think this is an issue of the UI5 Tooling, you might " +
 		"report it using the following URL: https://github.com/SAP/ui5-tooling/issues/new/choose",
 		"Correct last log line");
 
-	t.deepEqual(err.exitCode, 1, "Process was exited with code 1");
+	t.is(err.exitCode, 1, "Process was exited with code 1");
 });
 
 test.serial.cb("Unexpected error handling", (t) => {

--- a/test/lib/cli/commands/versions.js
+++ b/test/lib/cli/commands/versions.js
@@ -27,5 +27,5 @@ test.serial("Error: returns not installed if version was not found", (t) => {
 test.serial("Error: throws with error if error occurred while processing", async (t) => {
 	sinon.stub(versions, "getVersion").throws(new Error("Error occurred"));
 	const error = await t.throwsAsync(versions.handler({}));
-	t.deepEqual(error.message, "Error occurred", "Correct error message thrown");
+	t.is(error.message, "Error occurred", "Correct error message thrown");
 });

--- a/test/lib/cli/middlewares/base.js
+++ b/test/lib/cli/middlewares/base.js
@@ -11,7 +11,7 @@ test.afterEach("Stubs Cleanup", (t) => {
 	sinon.restore();
 });
 
-test.serial("uses default middleware", async (t) => {
+test.serial("uses default middleware", (t) => {
 	baseMiddleware({loglevel: 1});
 	t.is(logger.init.called, true, "Logger middleware initialized");
 });

--- a/test/lib/framework/add.js
+++ b/test/lib/framework/add.js
@@ -68,7 +68,7 @@ test.serial("Add without existing libraries in config", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
 		"getFrameworkResolver called with expected framework");
 
 	t.is(getLibraryMetadataStub.callCount, 1, "Resolver.getLibraryMetadata should be called once");
@@ -121,7 +121,7 @@ test.serial("Add with existing libraries in config", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
 		"getFrameworkResolver called with expected framework");
 
 	t.is(getLibraryMetadataStub.callCount, 2, "Resolver.getLibraryMetadata should be called twice");
@@ -184,7 +184,7 @@ test.serial("Add optional with existing libraries in config", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
 		"getFrameworkResolver called with expected framework");
 
 	t.is(getLibraryMetadataStub.callCount, 2, "Resolver.getLibraryMetadata should be called twice");
@@ -349,7 +349,7 @@ test.serial("Add with failing library metadata call", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
 		"getFrameworkResolver called with expected framework");
 
 	t.is(getLibraryMetadataStub.callCount, 1, "Resolver.getLibraryMetadata should be called once");
@@ -395,7 +395,7 @@ test.serial("Add with failing YAML update", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
 		"getFrameworkResolver called with expected framework");
 
 	t.is(getLibraryMetadataStub.callCount, 1, "Resolver.getLibraryMetadata should be called once");
@@ -448,7 +448,7 @@ test.serial("Add with failing YAML update (unexpected error)", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
 		"getFrameworkResolver called with expected framework");
 
 	t.is(getLibraryMetadataStub.callCount, 1, "Resolver.getLibraryMetadata should be called once");
@@ -493,7 +493,7 @@ test.serial("Add should not modify input parameters", async (t) => {
 	});
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
 		"getFrameworkResolver called with expected framework");
 
 	t.deepEqual(libraries, [{name: "sap.ui.lib2"}], "libraries array should not be changed");
@@ -530,7 +530,7 @@ test.serial("Add with projectGraphOptions.config", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
 		"getFrameworkResolver called with expected framework");
 	t.is(getLibraryMetadataStub.callCount, 1, "Resolver.getLibraryMetadata should be called once");
 	t.deepEqual(getLibraryMetadataStub.getCall(0).args, ["sap.ui.lib1"],

--- a/test/lib/framework/updateYaml.js
+++ b/test/lib/framework/updateYaml.js
@@ -45,7 +45,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 ---
 metadata:
   name: my-project
@@ -89,7 +89,7 @@ shims:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 specVersion: "2.0"
 metadata:
   name: my-project
@@ -145,7 +145,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 specVersion: "1.0"
 kind: extension
 metadata:
@@ -186,7 +186,7 @@ metadata:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -215,7 +215,7 @@ metadata:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -248,7 +248,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -281,7 +281,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -317,7 +317,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -358,7 +358,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -399,7 +399,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -437,7 +437,7 @@ resources:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -478,7 +478,7 @@ resources:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -523,7 +523,7 @@ resources:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -568,7 +568,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -610,7 +610,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -656,7 +656,7 @@ resources:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -707,7 +707,7 @@ resources:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -754,7 +754,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -851,7 +851,7 @@ something: else
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 metadata:
   name: my-project
 framework:
@@ -893,7 +893,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "dir", "other-file.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 ---
 metadata:
   name: my-project
@@ -933,7 +933,7 @@ framework:
 	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
 	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("/", "dir", "other-file.yaml"),
 		"writeFile should be called with expected path");
-	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[1], `
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
 ---
 metadata:
   name: my-project

--- a/test/lib/framework/use.js
+++ b/test/lib/framework/use.js
@@ -71,7 +71,7 @@ test.serial("Use with name and version (OpenUI5)", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
 		"getFrameworkResolver called with expected framework");
 	t.is(resolveVersionStub.callCount, 1, "Resolver#resolveVersion should be called once");
 	t.deepEqual(resolveVersionStub.getCall(0).args, ["latest", {cwd: "my-project-path"}],
@@ -128,7 +128,7 @@ test.serial("Use with name and version (SAPUI5)", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
 		"getFrameworkResolver called with expected framework");
 	t.is(resolveVersionStub.callCount, 1, "Resolver#resolveVersion should be called once");
 	t.deepEqual(resolveVersionStub.getCall(0).args, ["latest", {cwd: "my-project-path"}],
@@ -186,7 +186,7 @@ test.serial("Use with version only (OpenUI5)", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
 		"getFrameworkResolver called with expected framework");
 	t.is(resolveVersionStub.callCount, 1, "Resolver#resolveVersion should be called once");
 	t.deepEqual(resolveVersionStub.getCall(0).args, ["latest", {cwd: "my-project-path"}],
@@ -244,7 +244,7 @@ test.serial("Use with version only (SAPUI5)", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
 		"getFrameworkResolver called with expected framework");
 	t.is(resolveVersionStub.callCount, 1, "Resolver#resolveVersion should be called once");
 	t.deepEqual(resolveVersionStub.getCall(0).args, ["latest", {cwd: "my-project-path"}],
@@ -354,7 +354,7 @@ test.serial("Use with name only (existing framework configuration)", async (t) =
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
 		"getFrameworkResolver called with expected framework");
 	t.is(resolveVersionStub.callCount, 1, "Resolver#resolveVersion should be called once");
 	t.deepEqual(resolveVersionStub.getCall(0).args, ["1.76.0", {cwd: "my-project-path"}],
@@ -411,7 +411,7 @@ test.serial("Use with projectGraphOptions.config", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "SAPUI5",
 		"getFrameworkResolver called with expected framework");
 	t.is(resolveVersionStub.callCount, 1, "Resolver#resolveVersion should be called once");
 	t.deepEqual(resolveVersionStub.getCall(0).args, ["latest", {cwd: "my-project-path"}],
@@ -581,7 +581,7 @@ test.serial("Use with name and version (YAML update fails)", async (t) => {
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
 		"getFrameworkResolver called with expected framework");
 	t.is(resolveVersionStub.callCount, 1, "Resolver#resolveVersion should be called once");
 	t.deepEqual(resolveVersionStub.getCall(0).args, ["latest", {cwd: "my-project-path"}],
@@ -636,7 +636,7 @@ test.serial("Use with name and version (YAML update fails with unexpected error)
 		"generateProjectGraph should be called with expected args");
 
 	t.is(getFrameworkResolverStub.callCount, 1, "getFrameworkResolverStub should be called once");
-	t.deepEqual(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
+	t.is(getFrameworkResolverStub.getCall(0).args[0], "OpenUI5",
 		"getFrameworkResolver called with expected framework");
 	t.is(resolveVersionStub.callCount, 1, "Resolver#resolveVersion should be called once");
 	t.deepEqual(resolveVersionStub.getCall(0).args, ["latest", {cwd: "my-project-path"}],


### PR DESCRIPTION
Introducing [eslint-plugin-ava](https://github.com/avajs/eslint-plugin-ava/) to avoid common pitfalls when writing powerful ava tests.

- Add plugin to eslint config and package.json
- Restructure current code base to latest recommendations