### PR TITLE
[INTERNAL] Only import update-notifier when it's not disabled

### DIFF
--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -1,4 +1,3 @@
-import updateNotifier from "update-notifier";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 import {setVersion} from "./version.js";
@@ -13,14 +12,25 @@ async function getCommands() {
 }
 
 export default async (pkg) => {
-	updateNotifier({
-		pkg,
-		updateCheckInterval: 86400000, // 1 day
-		shouldNotifyInNpmScript: true
-	}).notify();
+	// Only import update-notifier when it's not disabled
+	// See https://github.com/yeoman/update-notifier/blob/3046d0f61a57f8270291b6ab271f8a12df8421a6/update-notifier.js#L57-L60
+	// The "is-ci" check is not executed, but will be checked by update-notifier itself then
+	const NO_UPDATE_NOTIFIER = "--no-update-notifier";
+	const disableUpdateNotifier =
+			"NO_UPDATE_NOTIFIER" in process.env ||
+			process.env.NODE_ENV === "test" ||
+			process.argv.includes(NO_UPDATE_NOTIFIER);
+
+	if (!disableUpdateNotifier) {
+		const {default: updateNotifier} = await import("update-notifier");
+		updateNotifier({
+			pkg,
+			updateCheckInterval: 86400000, // 1 day
+			shouldNotifyInNpmScript: true
+		}).notify();
+	}
 
 	// Remove --no-update-notifier from argv as it's not known to yargs, but we still want to support using it
-	const NO_UPDATE_NOTIFIER = "--no-update-notifier";
 	if (process.argv.includes(NO_UPDATE_NOTIFIER)) {
 		process.argv = process.argv.filter((v) => v !== NO_UPDATE_NOTIFIER);
 	}

--- a/test/bin/ui5.js
+++ b/test/bin/ui5.js
@@ -332,12 +332,11 @@ test.serial("integration: Executing main when required as main module (catch ini
 
 	process.argv = [...process.argv, "foo"];
 
-	// Provide empty package.json so that update-notifier (executed via lib/cli/cli) fails
-	const packageJsonModule = new Module("../../package.json");
-	packageJsonModule.exports = {};
-	require.cache[require.resolve("../../package.json")] = packageJsonModule;
-
-	require("../../bin/ui5.cjs");
+	const ui5 = require("../../bin/ui5.cjs");
+	// Immediately overwrite invokeCLI function before it is called
+	ui5.invokeCLI = async () => {
+		throw new Error("TEST: Unable to invoke CLI");
+	};
 
 	const errorCode = await processExit;
 	t.is(errorCode, 1);
@@ -347,5 +346,5 @@ test.serial("integration: Executing main when required as main module (catch ini
 	t.deepEqual(consoleLogStub.getCall(0).args, ["Fatal Error: Unable to initialize UI5 CLI"]);
 	t.is(consoleLogStub.getCall(1).args.length, 1);
 	t.true(consoleLogStub.getCall(1).args[0] instanceof Error);
-	t.is(consoleLogStub.getCall(1).args[0].message, "pkg.name and pkg.version required");
+	t.is(consoleLogStub.getCall(1).args[0].message, "TEST: Unable to invoke CLI");
 });

--- a/test/lib/cli/cli.js
+++ b/test/lib/cli/cli.js
@@ -4,6 +4,8 @@ import esmock from "esmock";
 import {fileURLToPath} from "node:url";
 
 test.beforeEach(async (t) => {
+	t.context.originalNodeEnv = process.env.NODE_ENV;
+
 	t.context.updateNotifierNotify = sinon.stub();
 	t.context.updateNotifier = sinon.stub().returns({
 		notify: t.context.updateNotifierNotify
@@ -69,6 +71,7 @@ test.beforeEach(async (t) => {
 test.afterEach.always((t) => {
 	sinon.restore();
 	esmock.purge(t.context.cli);
+	process.env.NODE_ENV = t.context.originalNodeEnv;
 });
 
 test.serial("CLI", async (t) => {
@@ -80,6 +83,9 @@ test.serial("CLI", async (t) => {
 	const pkg = {
 		version: "0.0.0-test"
 	};
+
+	// Remove NODE_ENV=test to allow execution of update-notifier
+	delete process.env.NODE_ENV;
 
 	await cli(pkg);
 
@@ -142,4 +148,18 @@ test.serial("CLI", async (t) => {
 		yargsInstance.wrap,
 		argvGetter
 	);
+});
+
+test.serial("CLI (NODE_ENV=test disables update-notifier)", async (t) => {
+	const {
+		cli, updateNotifier
+	} = t.context;
+
+	const pkg = {
+		version: "0.0.0-test"
+	};
+
+	await cli(pkg);
+
+	t.is(updateNotifier.callCount, 0);
 });


### PR DESCRIPTION
This is done to improve performance by reducing the overhead of loading
the dependency in cases where it is not needed.

Based on changes for v2 via https://github.com/SAP/ui5-cli/pull/533
