### PR TITLE
[INTERNAL] add/use: Integrate Sapui5MavenSnapshotResolver

### DIFF
--- a/lib/framework/add.js
+++ b/lib/framework/add.js
@@ -17,24 +17,27 @@ export default async function({projectGraphOptions, libraries}) {
 		);
 	}
 
-	if (!project.getFrameworkName()) {
+	const frameworkName = project.getFrameworkName();
+	const frameworkVersion = project.getFrameworkVersion();
+
+	if (!frameworkName) {
 		throw new Error(
 			`Project ${project.getName()} is missing a framework configuration. ` +
 			`Please use "ui5 use" to configure a framework and version.`
 		);
 	}
-	if (!project.getFrameworkVersion()) {
+	if (!frameworkVersion) {
 		throw new Error(
 			`Project ${project.getName()} does not define a framework version configuration. ` +
 			`Please use "ui5 use" to configure a version.`
 		);
 	}
 
-	const Resolver = getFrameworkResolver(project.getFrameworkName());
+	const Resolver = await getFrameworkResolver(frameworkName, frameworkVersion);
 
 	const resolver = new Resolver({
 		cwd: project.getRootPath(),
-		version: project.getFrameworkVersion()
+		version: frameworkVersion
 	});
 
 	// Get metadata of all libraries to verify that they can be installed
@@ -42,7 +45,7 @@ export default async function({projectGraphOptions, libraries}) {
 		try {
 			await resolver.getLibraryMetadata(name);
 		} catch (err) {
-			throw new Error(`Failed to find ${project.getFrameworkName()} framework library ${name}: ` + err.message);
+			throw new Error(`Failed to find ${frameworkName} framework library ${name}: ` + err.message);
 		}
 	}));
 

--- a/lib/framework/use.js
+++ b/lib/framework/use.js
@@ -1,7 +1,8 @@
 import {getRootProjectConfiguration, getFrameworkResolver} from "./utils.js";
 
 async function resolveVersion({frameworkName, frameworkVersion}, resolverOptions) {
-	return await getFrameworkResolver(frameworkName).resolveVersion(frameworkVersion, resolverOptions);
+	const Resolver = await getFrameworkResolver(frameworkName, frameworkVersion);
+	return Resolver.resolveVersion(frameworkVersion, resolverOptions);
 }
 
 function getEffectiveFrameworkName({project, frameworkOptions}) {

--- a/lib/framework/utils.js
+++ b/lib/framework/utils.js
@@ -1,6 +1,4 @@
 import {graphFromStaticFile, graphFromPackageDependencies} from "@ui5/project/graph";
-import Sapui5Resolver from "@ui5/project/ui5Framework/Sapui5Resolver";
-import Openui5Resolver from "@ui5/project/ui5Framework/Openui5Resolver";
 
 export async function getRootProjectConfiguration(projectGraphOptions) {
 	let graph;
@@ -19,11 +17,14 @@ export async function getRootProjectConfiguration(projectGraphOptions) {
 	return graph.getRoot();
 }
 
-export function getFrameworkResolver(frameworkName) {
-	if (frameworkName === "SAPUI5") {
-		return Sapui5Resolver;
+export async function getFrameworkResolver(frameworkName, frameworkVersion) {
+	if (frameworkVersion.toLowerCase().endsWith("-snapshot")) {
+		// Framework version could be for example: "latest-snapshot" or "1.112.0-SNAPSHOT"
+		return (await import("@ui5/project/ui5Framework/Sapui5MavenSnapshotResolver")).default;
 	} else if (frameworkName === "OpenUI5") {
-		return Openui5Resolver;
+		return (await import("@ui5/project/ui5Framework/Openui5Resolver")).default;
+	} else if (frameworkName === "SAPUI5") {
+		return (await import("@ui5/project/ui5Framework/Sapui5Resolver")).default;
 	} else {
 		throw new Error("Invalid framework.name: " + frameworkName);
 	}

--- a/test/lib/framework/add.js
+++ b/test/lib/framework/add.js
@@ -21,7 +21,7 @@ function createMockProject(attr) {
 test.beforeEach(async (t) => {
 	t.context.getRootProjectConfigurationStub = sinon.stub();
 	t.context.getLibraryMetadataStub = sinon.stub();
-	t.context.getFrameworkResolverStub = sinon.stub().returns(function Resolver() {
+	t.context.getFrameworkResolverStub = sinon.stub().resolves(function Resolver() {
 		return {
 			getLibraryMetadata: t.context.getLibraryMetadataStub
 		};

--- a/test/lib/framework/use.js
+++ b/test/lib/framework/use.js
@@ -20,7 +20,7 @@ function createMockProject(attr) {
 test.beforeEach(async (t) => {
 	t.context.getRootProjectConfigurationStub = sinon.stub();
 	t.context.resolveVersionStub = sinon.stub();
-	t.context.getFrameworkResolverStub = sinon.stub().returns({
+	t.context.getFrameworkResolverStub = sinon.stub().resolves({
 		resolveVersion: t.context.resolveVersionStub
 	});
 	t.context.updateYamlStub = sinon.stub();

--- a/test/lib/framework/utils.js
+++ b/test/lib/framework/utils.js
@@ -12,17 +12,25 @@ test.beforeEach(async (t) => {
 
 	t.context.Sapui5Resolver = sinon.stub();
 	t.context.Openui5Resolver = sinon.stub();
-	t.context.utils = await esmock("../../../lib/framework/utils.js", {
+	t.context.Sapui5MavenSnapshotResolver = sinon.stub();
+	t.context.utils = await esmock.p("../../../lib/framework/utils.js", {
 		"@ui5/project/graph": {
 			graphFromStaticFile: t.context.graphFromStaticFile,
 			graphFromPackageDependencies: t.context.graphFromPackageDependencies
 		},
-		"@ui5/project/ui5Framework/Sapui5Resolver": t.context.Sapui5Resolver,
-		"@ui5/project/ui5Framework/Openui5Resolver": t.context.Openui5Resolver
+		"@ui5/project/ui5Framework/Sapui5Resolver": {
+			default: t.context.Sapui5Resolver
+		},
+		"@ui5/project/ui5Framework/Openui5Resolver": {
+			default: t.context.Openui5Resolver
+		},
+		"@ui5/project/ui5Framework/Sapui5MavenSnapshotResolver": {
+			default: t.context.Sapui5MavenSnapshotResolver
+		},
 	});
 });
 
-test.afterEach.always(() => {
+test.afterEach.always((t) => {
 	sinon.restore();
 });
 
@@ -70,26 +78,42 @@ test.serial("getRootProjectConfiguration: config", async (t) => {
 	t.is(result, t.context.graph.getRoot.getCall(0).returnValue);
 });
 
-test.serial("getFrameworkResolver: SAPUI5", (t) => {
+test.serial("getFrameworkResolver: SAPUI5", async (t) => {
 	const {getFrameworkResolver} = t.context.utils;
 	const {Sapui5Resolver} = t.context;
 
-	const result = getFrameworkResolver("SAPUI5");
+	const result = await getFrameworkResolver("SAPUI5", "1.100.0");
 	t.is(result, Sapui5Resolver);
 });
 
-test.serial("getFrameworkResolver: OpenUI5", (t) => {
+test.serial("getFrameworkResolver: OpenUI5", async (t) => {
 	const {getFrameworkResolver} = t.context.utils;
-	const {Sapui5Resolver} = t.context;
+	const {Openui5Resolver} = t.context;
 
-	const result = getFrameworkResolver("SAPUI5");
-	t.is(result, Sapui5Resolver);
+	const result = await getFrameworkResolver("OpenUI5", "1.100.0");
+	t.is(result, Openui5Resolver);
 });
 
-test.serial("getFrameworkResolver: Invalid framework.name", (t) => {
+test.serial("getFrameworkResolver: OpenUI5 Snapshot", async (t) => {
+	const {getFrameworkResolver} = t.context.utils;
+	const {Sapui5MavenSnapshotResolver} = t.context;
+
+	const result = await getFrameworkResolver("OpenUI5", "1.100.0-SNAPSHOT");
+	t.is(result, Sapui5MavenSnapshotResolver);
+});
+
+test.serial("getFrameworkResolver: SAPUI5 Snapshot", async (t) => {
+	const {getFrameworkResolver} = t.context.utils;
+	const {Sapui5MavenSnapshotResolver} = t.context;
+
+	const result = await getFrameworkResolver("SAPUI5", "1.100.0-SNAPSHOT");
+	t.is(result, Sapui5MavenSnapshotResolver);
+});
+
+test.serial("getFrameworkResolver: Invalid framework.name", async (t) => {
 	const {getFrameworkResolver} = t.context.utils;
 
-	t.throws(() => getFrameworkResolver("UI5"), {
+	await t.throwsAsync(() => getFrameworkResolver("UI5", "1.100.0"), {
 		message: "Invalid framework.name: UI5"
 	});
 });


### PR DESCRIPTION
Enables commands like `ui5 use 1.114.0-SNAPSHOT`, `ui5 use 1.112-SNAPSHOT` (resolving to the latest patch) and `ui5 use latest-snapshot`

Depends on https://github.com/SAP/ui5-project/pull/570