### PR TITLE
[INTERNAL] consolidate-changelogs.js: Fix missing newline

### DIFF
--- a/.chglog/consolidate-changelogs.js
+++ b/.chglog/consolidate-changelogs.js
@@ -30,6 +30,9 @@ function handleDependencyBump(line) {
     - Changes contained in [${moduleName}@${moduleVersion}](${repoUrl}):
 
 ${versionChangelog}`;
+		} else {
+			// In case of an empty changelog: Only add the required newline
+			line += "\n";
 		}
 	}
 	return line;


### PR DESCRIPTION
If a dependencies changelog is empty, we still need to add a newline
after the bullet point for the dependency version bump.