### PR TITLE
[INTERNAL] Remove call to @ui5/logger#setShowProgress

### DIFF
--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -112,11 +112,9 @@ build.builder = function(cli) {
 };
 
 async function handleBuild(argv) {
-	const {default: logger} = await import("@ui5/logger");
 	const {graphFromStaticFile, graphFromPackageDependencies} = await import("@ui5/project/graph");
 
 	const command = argv._[argv._.length - 1];
-	logger.setShowProgress(true);
 
 	let graph;
 	if (argv.dependencyDefinition) {


### PR DESCRIPTION
Function is deprecated as per https://github.com/SAP/ui5-logger/pull/353