### PR TITLE
[INTERNAL] Refference the correct url for the logo

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -26,7 +26,7 @@
     "openGraph": {
         "title": "UI5 Tooling - API Reference",
         "type": "website",
-        "image": "https://sap.github.io/ui5-tooling/docs/images/UI5_logo_wide.png",
+        "image": "https://sap.github.io/ui5-tooling/v2/images/UI5_logo_wide.png",
         "site_name": "UI5 Tooling - API Reference",
         "url": "https://sap.github.io/ui5-tooling/"
     },


### PR DESCRIPTION
v2 change for links update like the one for v3 https://github.com/SAP/ui5-tooling/pull/725