### PR TITLE
[INTERNAL] Re-enable in-solidarity.yml inclusive language check

### DIFF
--- a/.github/in-solidarity.yml
+++ b/.github/in-solidarity.yml
@@ -1,0 +1,1 @@
+_extends: ietf/terminology


### PR DESCRIPTION
This re-enables the advanced in-solidarity check which was already active in branch "v2" but was forgotten move to "main".