### PR TITLE
[INTERNAL] base: Stop ConsoleWriter on exceptions

### DIFF
--- a/lib/cli/base.js
+++ b/lib/cli/base.js
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import {isLogLevelEnabled} from "@ui5/logger";
+import ConsoleWriter from "@ui5/logger/writers/Console";
 
 export default function(cli) {
 	cli.usage("Usage: ui5 <command> [options]")
@@ -87,6 +88,7 @@ export default function(cli) {
 			"Execute command with the maximum log output")
 		.fail(function(msg, err, yargs) {
 			if (err) {
+				ConsoleWriter.stop();
 				// Exception
 				if (isLogLevelEnabled("error")) {
 					console.log("");


### PR DESCRIPTION
Otherwise terminal settings are not restored (e.g. cursor disappears).
Depends on https://github.com/SAP/ui5-logger/pull/375