### PR TITLE
[FIX] updateYaml: Array update preserves indentation of following node

### DIFF
--- a/lib/framework/updateYaml.js
+++ b/lib/framework/updateYaml.js
@@ -1,7 +1,7 @@
 import path from "node:path";
 import {readFile, writeFile} from "node:fs/promises";
 import {loadAll, dump} from "js-yaml";
-import {fromYaml, getPosition, getValue} from "data-with-position";
+import {fromYaml, getPosition, getValue, getKind} from "data-with-position";
 import {getLogger} from "@ui5/logger";
 
 const log = getLogger("cli:framework:updateYaml");
@@ -110,7 +110,23 @@ function getValueFromPath(data, path) {
 }
 
 function getPositionFromPath(positionData, path) {
-	return getPosition(getValueFromPath(positionData, path));
+	const data = getValueFromPath(positionData, path);
+	const position = getPosition(data);
+	const kind = getKind(data);
+	if ((kind === "array" && data.length) || kind === "object") {
+		// data-with-position treats arrays and objects different from primitives:
+		// The end index of such nodes always reaches up to the beginning of the following node, instead of the end
+		// of the contained data.
+		// For example, if an array has entries, the end position of the array is *directly* at the beginning of
+		// the next node instead of at the end of the last entry.
+		// Typically this means one line and multiple columns *after* the array ended.
+		// However, if an array has no entries (e.g. "[]"), the end is directly after the end of that data and
+		// *not* in the next line (this appears to be an inconsistency).
+		// Therefore, in case we encounter an array *with entries*, or an object, we reset the end column to "1"
+		// to prevent replacing (i.e. removing) the indentation of the following node.
+		position.end.column = 1;
+	}
+	return position;
 }
 
 function formatValue(value, indent) {

--- a/test/lib/framework/updateYaml.js
+++ b/test/lib/framework/updateYaml.js
@@ -673,6 +673,54 @@ resources:
 `, "writeFile should be called with expected content");
 });
 
+test.serial("Should add new array elements to document with content below on same level", async (t) => {
+	t.context.fsReadFileStub.resolves(`
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  libraries:
+    - name: sap.ui.core
+  version: "1.76.0"
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
+`);
+
+	await updateYaml({
+		project: {
+			getRootPath: () => "my-project",
+			getName: () => "my-project"
+		},
+		data: {
+			framework: {
+				libraries: [
+					{name: "sap.ui.core"},
+					{name: "sap.m"},
+					{name: "sap.ui.layout"},
+				]
+			}
+		}
+	});
+
+	t.is(t.context.fsWriteFileStub.callCount, 1, "fs.writeFile should be called once");
+	t.deepEqual(t.context.fsWriteFileStub.getCall(0).args[0], path.join("my-project", "ui5.yaml"),
+		"writeFile should be called with expected path");
+	t.is(t.context.fsWriteFileStub.getCall(0).args[1], `
+metadata:
+  name: my-project
+framework:
+  name: OpenUI5
+  libraries:
+    - name: sap.ui.core
+    - name: sap.m
+    - name: sap.ui.layout
+  version: "1.76.0"
+resources:
+  configuration:
+    propertiesFileSourceEncoding: UTF-8
+`, "writeFile should be called with expected content");
+});
 
 test.serial("Should add new array elements to document with content separated by empty line below", async (t) => {
 	t.context.fsReadFileStub.resolves(`


### PR DESCRIPTION
See added comment for details. This seems to be an overlooked behavior
of data-with-position. It can also be observed in the respective tests:
The 'str' array ends in line 11, column 3:
https://github.com/gicentre/litvis/blob/855268e33ef40be1b03062eacefad79fadbf6b4e/packages/data-with-position/src/__fixtures__/fromYaml/basic.config.ts#L73
Which is actually the beginning of the next node:
https://github.com/gicentre/litvis/blob/855268e33ef40be1b03062eacefad79fadbf6b4e/packages/data-with-position/src/__fixtures__/fromYaml/basic.yaml#L11