### PR TITLE
[FIX] Exit with code 1 when using unsupported Node.js version

### DIFF
--- a/bin/ui5.cjs
+++ b/bin/ui5.cjs
@@ -84,11 +84,12 @@ const ui5 = {
 	async main() {
 		const pkg = ui5.getPackageJson();
 		if (!ui5.checkRequirements({pkg, nodeVersion: process.version})) {
-			return;
-		}
-		const localInstallationInvoked = await ui5.invokeLocalInstallation(pkg);
-		if (!localInstallationInvoked) {
-			await ui5.invokeCLI(pkg);
+			process.exit(1);
+		} else {
+			const localInstallationInvoked = await ui5.invokeLocalInstallation(pkg);
+			if (!localInstallationInvoked) {
+				await ui5.invokeCLI(pkg);
+			}
 		}
 	}
 };

--- a/test/bin/ui5.js
+++ b/test/bin/ui5.js
@@ -226,6 +226,14 @@ test.serial("invokeLocalInstallation: Doesn't invoke local installation when it 
 test.serial("main (unsupported Node.js version)", async (t) => {
 	const {sinon, consoleLogStub} = t.context;
 
+	const processExit = new Promise((resolve) => {
+		const processExitStub = sinon.stub(process, "exit");
+		processExitStub.callsFake((errorCode) => {
+			processExitStub.restore();
+			resolve(errorCode);
+		});
+	});
+
 	const ui5 = require("../../bin/ui5.cjs");
 	const {main} = ui5;
 
@@ -234,6 +242,9 @@ test.serial("main (unsupported Node.js version)", async (t) => {
 	sinon.stub(ui5, "invokeCLI");
 
 	await main();
+
+	const errorCode = await processExit;
+	t.is(errorCode, 1);
 
 	t.is(consoleLogStub.callCount, 0);
 
@@ -245,6 +256,8 @@ test.serial("main (unsupported Node.js version)", async (t) => {
 test.serial("main (invocation of local installation)", async (t) => {
 	const {sinon, consoleLogStub} = t.context;
 
+	const processExitStub = sinon.stub(process, "exit");
+
 	const ui5 = require("../../bin/ui5.cjs");
 	const {main} = ui5;
 
@@ -253,6 +266,7 @@ test.serial("main (invocation of local installation)", async (t) => {
 
 	await main();
 
+	t.is(processExitStub.callCount, 0);
 	t.is(consoleLogStub.callCount, 0);
 
 	t.is(ui5.invokeLocalInstallation.callCount, 1);


### PR DESCRIPTION
The process should fail when using an unsupported Node.js version as
indication that something went wrong.
This is important for other tools or automated executions (e.g. CI) to
detect that the command couldn't be executed.
