### PR TITLE
[INTERNAL] use correct option to show in docs

### DIFF
--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -21,7 +21,7 @@ build.builder = function(cli) {
 		})
 		.command("self-contained",
 			"Build project and create self-contained bundle. " +
-			"Recommended to be used in conjunction with --include-dependencies", {
+			"Recommended to be used in conjunction with --include-all-dependencies", {
 				handler: handleBuild,
 				builder: noop,
 				middlewares: [baseMiddleware]


### PR DESCRIPTION
Only can find the command `--include-dependencies` in this line and in the documentation.  
Should it be `--include-all-dependencies` ?

**Thank you for your contribution!** 🙌

To get it merged faster, kindly review the checklist below:

## Pull Request Checklist
- [ ] Reviewed the [Contributing Guidelines](https://github.com/SAP/ui5-tooling/blob/main/CONTRIBUTING.md#-contributing-code)
    + Especially the [How to Contribute](https://github.com/SAP/ui5-tooling/blob/main/CONTRIBUTING.md#how-to-contribute) section 
- [ ] [No merge commits](https://github.com/SAP/ui5-tooling/blob/main/docs/Guidelines.md#no-merge-commits)
- [ ] [Correct commit message style](https://github.com/SAP/ui5-tooling/blob/main/docs/Guidelines.md#commit-message-style)
