### PR TITLE
[INTERNAL] build: Add details to include-dependency options

### DIFF
--- a/lib/cli/base.js
+++ b/lib/cli/base.js
@@ -27,7 +27,7 @@ export default function(cli) {
 		})
 		.option("loglevel", {
 			alias: "log-level",
-			describe: "Set the logging level (silent|error|warn|info|perf|verbose|silly).",
+			describe: "Set the logging level",
 			default: "info",
 			type: "string",
 			choices: ["silent", "error", "warn", "info", "perf", "verbose", "silly"]

--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -27,7 +27,8 @@ build.builder = function(cli) {
 				middlewares: [baseMiddleware]
 			})
 		.option("include-all-dependencies", {
-			describe: "Include all dependencies in the build result",
+			describe: "Include all dependencies in the build result. " +
+				"This is equivalent to '--include-dependency \"*\"'",
 			alias: ["all", "a"],
 			default: false,
 			type: "boolean"
@@ -35,7 +36,8 @@ build.builder = function(cli) {
 		.option("include-dependency", {
 			describe: "A list of dependencies to be included in the build result. You can use the asterisk '*' as" +
 				" an alias for including all dependencies in the build result. The listed dependencies cannot be" +
-				" overruled by dependencies defined in 'exclude-dependency'.",
+				" overruled by dependencies defined in 'exclude-dependency'. " +
+				"The provided name must match with the dependency name shown in 'ui5 ls --flat'",
 			type: "string",
 			array: true
 		})
@@ -54,7 +56,8 @@ build.builder = function(cli) {
 		})
 		.option("exclude-dependency", {
 			describe: "A list of dependencies to be excluded from the build result. The listed dependencies can" +
-				" be overruled by dependencies defined in 'include-dependency'.",
+				" be overruled by dependencies defined in 'include-dependency'. " +
+				"The provided name must match with the dependency name shown in 'ui5 ls --flat'",
 			type: "string",
 			array: true
 		})

--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -106,7 +106,7 @@ build.builder = function(cli) {
 		})
 		.option("cache-mode", {
 			describe:
-				"Cache mode to use when consuming SNAPSHOT versions of a framework: 'Default', 'Force', or 'Off'. " +
+				"Cache mode to use when consuming SNAPSHOT versions of framework dependencies. " +
 				"The 'Default' behavior is to invalidate the cache after 9 hours. 'Force' uses the cache only and " +
 				"does not create any requests. 'Off' invalidates any existing cache and updates from the repository",
 			type: "string",

--- a/lib/cli/commands/serve.js
+++ b/lib/cli/commands/serve.js
@@ -67,7 +67,7 @@ serve.builder = function(cli) {
 		})
 		.option("cache-mode", {
 			describe:
-				"Cache mode to use when consuming SNAPSHOT versions of a framework: 'Default', 'Force', or 'Off'. " +
+				"Cache mode to use when consuming SNAPSHOT versions of framework dependencies. " +
 				"The 'Default' behavior is to invalidate the cache after 9 hours. 'Force' uses the cache only and " +
 				"does not create any requests. 'Off' invalidates any existing cache and updates from the repository",
 			type: "string",

--- a/lib/cli/commands/tree.js
+++ b/lib/cli/commands/tree.js
@@ -29,7 +29,7 @@ tree.builder = function(cli) {
 		})
 		.option("cache-mode", {
 			describe:
-				"Cache mode to use when consuming SNAPSHOT versions of a framework: 'Default', 'Force', or 'Off'. " +
+				"Cache mode to use when consuming SNAPSHOT versions of framework dependencies. " +
 				"The 'Default' behavior is to invalidate the cache after 9 hours. 'Force' uses the cache only and " +
 				"does not create any requests. 'Off' invalidates any existing cache and updates from the repository",
 			type: "string",


### PR DESCRIPTION
As per feedback provided in
https://github.com/SAP/ui5-tooling/issues/841#issuecomment-1613164131,
explain that the provided dependency names must match the ui5.yaml names
and not the npm module names.