### PR TITLE
[INTERNAL] Fix unit/coverage setup on Node 20 and adapt CI matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,13 +26,13 @@ strategy:
       node_version: 18.x
     linux_node_current:
       imageName: 'ubuntu-22.04'
-      node_version: 19.x
+      node_version: 20.x
     mac_node_current:
       imageName: 'macos-12'
-      node_version: 19.x
+      node_version: 20.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 19.x
+      node_version: 20.x
 
 pool:
   vmImage: $(imageName)

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
 		"nodeArguments": [
 			"--loader=esmock",
 			"--no-warnings"
-		]
+		],
+		"workerThreads": false
 	},
 	"nyc": {
 		"reporter": [


### PR DESCRIPTION
AVA's nodeArguments option doesn't seem to work with loaders on Node 20.
One solution is to disable worker threads to use child processes instead.
This should also stabilize test execution, especially when tests also
spawn new worker threads, which mainly appeared in ui5-builder.

See: https://github.com/SAP/ui5-server/pull/602
JIRA: CPOUI5FOUNDATION-612
