### PR TITLE
[FIX] ui5.yaml: Use double quotes for string values

### DIFF
--- a/lib/cli/commands/init.js
+++ b/lib/cli/commands/init.js
@@ -20,7 +20,7 @@ initCommand.handler = async function() {
 	}
 
 	const projectConfig = await init();
-	const yaml = jsYaml.dump(projectConfig);
+	const yaml = jsYaml.dump(projectConfig, {quotingType: `"`});
 
 	await writeFile(yamlPath, yaml);
 	console.log(`Wrote ui5.yaml to ${yamlPath}:\n`);

--- a/test/fixtures/init/application/ui5.yaml
+++ b/test/fixtures/init/application/ui5.yaml
@@ -1,4 +1,4 @@
-specVersion: '0.1'
+specVersion: "0.1"
 metadata:
   name: sample-app
 type: application

--- a/test/lib/cli/commands/init.js
+++ b/test/lib/cli/commands/init.js
@@ -10,12 +10,13 @@ test.afterEach.always((t) => {
 test.serial("Writes ui5.yaml to fs", async (t) => {
 	const ui5YamlPath = "./ui5.yaml";
 	const ui5Yaml = `
-	specVersion: '0.1'
+	specVersion: "0.1"
 	metadata:
 	name: sample-app
 	type: application`;
 
 	const fsWriteFileStub = sinon.stub().resolves();
+	const jsyamlDumpStub = sinon.stub().returns(ui5Yaml);
 
 	const initCommand = t.context.initCommand = await esmock.p("../../../../lib/cli/commands/init.js", {
 		"../../../../lib/utils/fsHelper": {
@@ -23,7 +24,7 @@ test.serial("Writes ui5.yaml to fs", async (t) => {
 		},
 		"../../../../lib/init/init": sinon.stub().resolves({}),
 		"js-yaml": {
-			dump: sinon.stub().returns(ui5Yaml)
+			dump: jsyamlDumpStub
 		},
 		"node:path": {
 			resolve: () => ui5YamlPath
@@ -37,6 +38,7 @@ test.serial("Writes ui5.yaml to fs", async (t) => {
 
 	t.is(fsWriteFileStub.getCall(0).args[0], ui5YamlPath, "Passes yaml path to write the yaml file to");
 	t.is(fsWriteFileStub.getCall(0).args[1], ui5Yaml, "Passes yaml content to write to fs");
+	t.deepEqual(jsyamlDumpStub.getCall(0).args[1], {quotingType: `"`}, "Enforce usage of double quotes in yaml files");
 });
 
 test.serial("Error: throws if ui5.yaml already exists", async (t) => {


### PR DESCRIPTION
Use `"` instead of `'` when writing yaml files.

Team decided to use double quotes.