### PR TITLE
[INTERNAL] New dynamic import mock for NodeJS >= 20.6.xx

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -46,7 +46,8 @@
 				"rimraf": "^5.0.5",
 				"sinon": "^16.1.3",
 				"strip-ansi": "^7.1.0",
-				"tap-xunit": "^2.4.1"
+				"tap-xunit": "^2.4.1",
+				"testdouble": "^3.20.0"
 			},
 			"engines": {
 				"node": "^16.18.0 || >=18.12.0",
@@ -5946,6 +5947,15 @@
 			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"dev": true
 		},
+		"node_modules/is-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+			"integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -8910,6 +8920,19 @@
 				}
 			]
 		},
+		"node_modules/quibble": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/quibble/-/quibble-0.9.0.tgz",
+			"integrity": "sha512-gpBmqaEPl0nNZuDq16sLO7g/aYcrldSIls8igHm5EYP02+Kzmn/DCNpcSGywnhTk6aNJXkUv6vrRDvrJyRJ2Xw==",
+			"dev": true,
+			"dependencies": {
+				"lodash": "^4.17.21",
+				"resolve": "^1.22.4"
+			},
+			"engines": {
+				"node": ">= 0.14.0"
+			}
+		},
 		"node_modules/quick-lru": {
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
@@ -10336,6 +10359,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/stringify-object-es5": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+			"integrity": "sha512-vE7Xdx9ylG4JI16zy7/ObKUB+MtxuMcWlj/WHHr3+yAlQoN6sst2stU9E+2Qs3OrlJw/Pf3loWxL1GauEHf6MA==",
+			"dev": true,
+			"dependencies": {
+				"is-plain-obj": "^1.0.0",
+				"is-regexp": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -10750,10 +10786,31 @@
 				"node": "*"
 			}
 		},
+		"node_modules/testdouble": {
+			"version": "3.20.0",
+			"resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.20.0.tgz",
+			"integrity": "sha512-P/wfyKF1P1AE8/VM6PXCtSQJyOgPObOg191TlVZnoSQw/hhFXvxIFM5yGJ7Bf9Hs0FX8677YCv3esVgPGSeTLg==",
+			"dev": true,
+			"dependencies": {
+				"lodash": "^4.17.21",
+				"quibble": "^0.9.0",
+				"stringify-object-es5": "^2.5.0",
+				"theredoc": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true
+		},
+		"node_modules/theredoc": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+			"integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
 			"dev": true
 		},
 		"node_modules/through2": {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
 		"eslint-config-google": "^0.14.0",
 		"eslint-plugin-ava": "^14.0.0",
 		"eslint-plugin-jsdoc": "^46.8.2",
+		"testdouble": "^3.20.0",
 		"esmock": "^2.5.9",
 		"execa": "^8.0.1",
 		"jsdoc": "^4.0.2",

--- a/test/bin/ui5.js
+++ b/test/bin/ui5.js
@@ -324,7 +324,6 @@ test.serial("integration: main / invokeCLI", async (t) => {
 
 test.serial("integration: Executing main when required as main module", async (t) => {
 	const {sinon, consoleLogStub} = t.context;
-	await td.reset();
 
 	const processExit = new Promise((resolve) => {
 		const processExitStub = sinon.stub(process, "exit");
@@ -351,7 +350,6 @@ test.serial("integration: Executing main when required as main module", async (t
 
 test.serial("integration: Executing main when required as main module (catch initialize error)", async (t) => {
 	const {sinon, consoleLogStub} = t.context;
-	await td.reset();
 
 	const processExit = new Promise((resolve) => {
 		const processExitStub = sinon.stub(process, "exit");


### PR DESCRIPTION
Fixes: https://github.com/SAP/ui5-tooling/issues/891

Node's module loading has changed since 20.6.xx. As `esmock` is unable to properly mock dynamic imports within CommonJS modules, we need to use another alternative for this test. `testdouble` seems to work pretty well for that case, but for NodeJS versions below 20.6.xx it needs a `--loader` flag and we already use that for `esmock`.

The solution would be to use the old mocking for older NodeJs versions and `testdouble` for the ones after 20.6.xx (no flag required here): https://github.com/testdouble/testdouble.js/blob/main/docs/7-replacing-dependencies.md#how-module-replacement-works-for-es-modules-using-import