### PR TITLE
[FEATURE] Add option to redefine output directory structure

### DIFF
--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -121,16 +121,16 @@ build.builder = function(cli) {
 			default: false,
 			type: "boolean"
 		})
-		.option("flat-output", {
+		.option("output-style", {
 			describe:
-				"Write the build results into a flat directory structure, omitting the project" +
-				"namespace and the \"resources\" directory." +
-				"This is currently only supported for projects of type 'library' and projects of " +
-				"type 'application' always result in flat output." +
+				"The way build results into a specific directory structure. " +
+				"\"Flat\" omits the project namespace and the \"resources\" directory. This is" +
+				" currently only supported for projects of type 'library'. Projects of " +
+				"type 'application' always have a default result as a flat output." +
 				"No other dependencies can be included in the build result.",
-			// We need to explicitly check wether the falsy value is explicit or not for project type "application"
-			// default: false,
-			type: "boolean"
+			type: "string",
+			default: "Default",
+			choices: ["Default", "Flat", "Namespace"],
 		})
 		.example("ui5 build", "Preload build for project without dependencies")
 		.example("ui5 build self-contained", "Self-contained build for project")
@@ -188,7 +188,7 @@ async function handleBuild(argv) {
 		includedTasks: argv["include-task"],
 		excludedTasks: argv["exclude-task"],
 		cssVariables: argv["experimental-css-variables"],
-		flatOutput: argv["flat-output"],
+		outputStyle: argv["output-style"],
 	});
 }
 

--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -129,8 +129,11 @@ build.builder = function(cli) {
 				"type 'application' always result in a flat output." +
 				"No other dependencies can be included in the build result.",
 			type: "string",
-			default: "default",
-			choices: ["default", "flat", "namespace"],
+			default: "Default",
+			choices: ["Default", "Flat", "Namespace"],
+		})
+		.coerce("output-style", (opt) => {
+			return opt.charAt(0).toUpperCase() + opt.slice(1).toLowerCase();
 		})
 		.example("ui5 build", "Preload build for project without dependencies")
 		.example("ui5 build self-contained", "Self-contained build for project")
@@ -188,7 +191,7 @@ async function handleBuild(argv) {
 		includedTasks: argv["include-task"],
 		excludedTasks: argv["exclude-task"],
 		cssVariables: argv["experimental-css-variables"],
-		outputStyle: (argv["output-style"].charAt(0).toUpperCase() + argv["output-style"].slice(1)),
+		outputStyle: argv["output-style"],
 	});
 }
 

--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -121,6 +121,15 @@ build.builder = function(cli) {
 			default: false,
 			type: "boolean"
 		})
+		.option("flat-output", {
+			describe:
+				"Write the build results into a flat directory structure, omitting the project" +
+				"namespace and the \"resources\" directory." +
+				"This is currently only supported for projects of type 'library'." +
+				"No other dependencies can be included in the build result." +
+				"Projects of type 'application' always result in flat output.",
+			type: "boolean"
+		})
 		.example("ui5 build", "Preload build for project without dependencies")
 		.example("ui5 build self-contained", "Self-contained build for project")
 		.example("ui5 build --exclude-task=* --include-task=minify generateComponentPreload",
@@ -176,7 +185,8 @@ async function handleBuild(argv) {
 		jsdoc: command === "jsdoc",
 		includedTasks: argv["include-task"],
 		excludedTasks: argv["exclude-task"],
-		cssVariables: argv["experimental-css-variables"]
+		cssVariables: argv["experimental-css-variables"],
+		flatOutput: argv["flat-output"],
 	});
 }
 

--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -123,11 +123,13 @@ build.builder = function(cli) {
 		})
 		.option("output-style", {
 			describe:
-				"Processes build results into a specific directory structure. " +
-				"\"Flat\" omits the project namespace and the \"resources\" directory. This is" +
-				" currently only supported for projects of type 'library'. Projects of " +
-				"type 'application' always result in a flat output." +
-				"No other dependencies can be included in the build result.",
+				"Processes build results into a specific directory structure. \r\n\r\n" +
+				"- Flat: Omits the project namespace and the \"resources\" directory.\r\n" +
+				"- Namespace: Respects the project namespace and the \"resources\" directory, " +
+					"maintaining the original structure.\r\n" +
+				"- Default: The default directory structure for every project type. For applications, " +
+					"this is identical to \"Flat\", and for libraries, it is \"Namespace\". Other types have a " +
+					"more distinct default output style.",
 			type: "string",
 			default: "Default",
 			choices: ["Default", "Flat", "Namespace"],

--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -123,10 +123,10 @@ build.builder = function(cli) {
 		})
 		.option("output-style", {
 			describe:
-				"The way build results into a specific directory structure. " +
+				"Processes build results into a specific directory structure. " +
 				"\"Flat\" omits the project namespace and the \"resources\" directory. This is" +
 				" currently only supported for projects of type 'library'. Projects of " +
-				"type 'application' always have a default result as a flat output." +
+				"type 'application' always result in a flat output." +
 				"No other dependencies can be included in the build result.",
 			type: "string",
 			default: "Default",

--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -125,9 +125,11 @@ build.builder = function(cli) {
 			describe:
 				"Write the build results into a flat directory structure, omitting the project" +
 				"namespace and the \"resources\" directory." +
-				"This is currently only supported for projects of type 'library'." +
-				"No other dependencies can be included in the build result." +
-				"Projects of type 'application' always result in flat output.",
+				"This is currently only supported for projects of type 'library' and projects of " +
+				"type 'application' always result in flat output." +
+				"No other dependencies can be included in the build result.",
+			// We need to explicitly check wether the falsy value is explicit or not for project type "application"
+			// default: false,
 			type: "boolean"
 		})
 		.example("ui5 build", "Preload build for project without dependencies")

--- a/lib/cli/commands/build.js
+++ b/lib/cli/commands/build.js
@@ -129,8 +129,8 @@ build.builder = function(cli) {
 				"type 'application' always result in a flat output." +
 				"No other dependencies can be included in the build result.",
 			type: "string",
-			default: "Default",
-			choices: ["Default", "Flat", "Namespace"],
+			default: "default",
+			choices: ["default", "flat", "namespace"],
 		})
 		.example("ui5 build", "Preload build for project without dependencies")
 		.example("ui5 build self-contained", "Self-contained build for project")
@@ -188,7 +188,7 @@ async function handleBuild(argv) {
 		includedTasks: argv["include-task"],
 		excludedTasks: argv["exclude-task"],
 		cssVariables: argv["experimental-css-variables"],
-		outputStyle: argv["output-style"],
+		outputStyle: (argv["output-style"].charAt(0).toUpperCase() + argv["output-style"].slice(1)),
 	});
 }
 

--- a/test/lib/cli/base.js
+++ b/test/lib/cli/base.js
@@ -281,3 +281,27 @@ test.serial("ui5 --no-update-notifier", async (t) => {
 	t.regex(stdout, /@ui5\/cli:/, "Output includes version information");
 	t.false(failed, "Command should not fail");
 });
+
+test.serial("ui5 --output-style", async (t) => {
+	await t.throwsAsync(ui5(["build", "--output-style", "nonExistent"]), {
+		message: /Argument: output-style, Given: "Nonexistent", Choices: "Default", "Flat", "Namespace"/s
+	}, "Coercion correctly capitalizes the first letter and makes the rest lowercase");
+
+
+	// "--output-style" uses a coerce to transform the input into the correct letter case.
+	// It is hard/unmaintainable to spy on internal implementation, so we check the output.
+	// The coerce goes before the real ui5 build, so we just need to check whether
+	// an invalid "--output-style" choice exception is not thrown.
+	// Of course, the build would throw another exception, because there's nothing actually to build.
+	await t.throwsAsync(ui5(["build", "--output-style", "flat"]), {
+		message: /^((?!Argument: output-style, Given: "Flat).)*$/s
+	}, "Does not throw an exception because of the --output-style input");
+
+	await t.throwsAsync(ui5(["build", "--output-style", "nAmEsPaCe"]), {
+		message: /^((?!Argument: output-style, Given: "Namespace).)*$/s
+	}, "Does not throw an exception because of the --output-style input");
+
+	await t.throwsAsync(ui5(["build", "--output-style", "Default"]), {
+		message: /^((?!Argument: output-style, Given: "Default).)*$/s
+	}, "Does not throw an exception because of the --output-style input");
+});

--- a/test/lib/cli/commands/build.js
+++ b/test/lib/cli/commands/build.js
@@ -374,7 +374,7 @@ test.serial("ui5 build --output-style", async (t) => {
 
 	await build.handler(argv);
 
-	expectedBuilderArgs.outputStyle = "flat";
+	expectedBuilderArgs.outputStyle = "Flat";
 	t.deepEqual(builder.getCall(0).args[0], expectedBuilderArgs,
 		"Build with activated outputStyle='flat' is called with expected arguments");
 });

--- a/test/lib/cli/commands/build.js
+++ b/test/lib/cli/commands/build.js
@@ -376,5 +376,5 @@ test.serial("ui5 build --output-style", async (t) => {
 
 	expectedBuilderArgs.outputStyle = "Flat";
 	t.deepEqual(builder.getCall(0).args[0], expectedBuilderArgs,
-		"Build with activated flatOutput is called with expected arguments");
+		"Build with activated outputStyle='Flat' is called with expected arguments");
 });

--- a/test/lib/cli/commands/build.js
+++ b/test/lib/cli/commands/build.js
@@ -25,7 +25,7 @@ function getDefaultArgv() {
 		"experimentalCssVariables": false,
 		"cache-mode": "Default",
 		"cacheMode": "Default",
-		"output-style": "default",
+		"output-style": "Default",
 		"$0": "ui5"
 	};
 }
@@ -370,11 +370,11 @@ test.serial("ui5 build --experimental-css-variables", async (t) => {
 test.serial("ui5 build --output-style", async (t) => {
 	const {build, argv, builder, expectedBuilderArgs} = t.context;
 
-	argv["output-style"] = "flat";
+	argv["output-style"] = "Flat";
 
 	await build.handler(argv);
 
 	expectedBuilderArgs.outputStyle = "Flat";
 	t.deepEqual(builder.getCall(0).args[0], expectedBuilderArgs,
-		"Build with activated outputStyle='flat' is called with expected arguments");
+		"Build with activated outputStyle='Flat' is called with expected arguments");
 });

--- a/test/lib/cli/commands/build.js
+++ b/test/lib/cli/commands/build.js
@@ -25,6 +25,7 @@ function getDefaultArgv() {
 		"experimentalCssVariables": false,
 		"cache-mode": "Default",
 		"cacheMode": "Default",
+		"output-style": "Default",
 		"$0": "ui5"
 	};
 }
@@ -51,7 +52,7 @@ function getDefaultBuilderArgs() {
 		includedTasks: undefined,
 		excludedTasks: undefined,
 		cssVariables: false,
-		flatOutput: undefined
+		outputStyle: "Default"
 	};
 }
 
@@ -366,14 +367,14 @@ test.serial("ui5 build --experimental-css-variables", async (t) => {
 		"Build with activated CSS Variables is called with expected arguments");
 });
 
-test.serial("ui5 build --flat-output", async (t) => {
+test.serial("ui5 build --output-style", async (t) => {
 	const {build, argv, builder, expectedBuilderArgs} = t.context;
 
-	argv["flat-output"] = true;
+	argv["output-style"] = "Flat";
 
 	await build.handler(argv);
 
-	expectedBuilderArgs.flatOutput = true;
+	expectedBuilderArgs.outputStyle = "Flat";
 	t.deepEqual(builder.getCall(0).args[0], expectedBuilderArgs,
 		"Build with activated flatOutput is called with expected arguments");
 });

--- a/test/lib/cli/commands/build.js
+++ b/test/lib/cli/commands/build.js
@@ -25,7 +25,7 @@ function getDefaultArgv() {
 		"experimentalCssVariables": false,
 		"cache-mode": "Default",
 		"cacheMode": "Default",
-		"output-style": "Default",
+		"output-style": "default",
 		"$0": "ui5"
 	};
 }
@@ -370,11 +370,11 @@ test.serial("ui5 build --experimental-css-variables", async (t) => {
 test.serial("ui5 build --output-style", async (t) => {
 	const {build, argv, builder, expectedBuilderArgs} = t.context;
 
-	argv["output-style"] = "Flat";
+	argv["output-style"] = "flat";
 
 	await build.handler(argv);
 
-	expectedBuilderArgs.outputStyle = "Flat";
+	expectedBuilderArgs.outputStyle = "flat";
 	t.deepEqual(builder.getCall(0).args[0], expectedBuilderArgs,
-		"Build with activated outputStyle='Flat' is called with expected arguments");
+		"Build with activated outputStyle='flat' is called with expected arguments");
 });

--- a/test/lib/cli/commands/build.js
+++ b/test/lib/cli/commands/build.js
@@ -364,3 +364,15 @@ test.serial("ui5 build --experimental-css-variables", async (t) => {
 	t.deepEqual(builder.getCall(0).args[0], expectedBuilderArgs,
 		"Build with activated CSS Variables is called with expected arguments");
 });
+
+test.serial("ui5 build --flat-output", async (t) => {
+	const {build, argv, builder, expectedBuilderArgs} = t.context;
+
+	argv["flat-output"] = true;
+
+	await build.handler(argv);
+
+	expectedBuilderArgs.flatOutput = true;
+	t.deepEqual(builder.getCall(0).args[0], expectedBuilderArgs,
+		"Build with activated flatOutput is called with expected arguments");
+});

--- a/test/lib/cli/commands/build.js
+++ b/test/lib/cli/commands/build.js
@@ -50,7 +50,8 @@ function getDefaultBuilderArgs() {
 		jsdoc: false,
 		includedTasks: undefined,
 		excludedTasks: undefined,
-		cssVariables: false
+		cssVariables: false,
+		flatOutput: undefined
 	};
 }
 


### PR DESCRIPTION
New CLI `build` option `--output-style`. Whether to omit the /resources/\<namespace\> directory structure in the build output.

Resolves https://github.com/SAP/ui5-tooling/issues/507
Depends on: https://github.com/SAP/ui5-project/pull/624