### PR TITLE
[BREAKING] Require Node.js 20.11.x/>=21.2.0 and npm >=10 

### DIFF
--- a/.chglog/consolidate-changelogs.js
+++ b/.chglog/consolidate-changelogs.js
@@ -1,18 +1,15 @@
 import readline from "node:readline";
 import path from "node:path";
 import fs from "node:fs";
-
-// Using CommonsJS require.resolve as long as import.meta.resolve is experimental
-import {createRequire} from "node:module";
-const require = createRequire(import.meta.url);
+import {fileURLToPath} from "node:url";
 
 function handleDependencyBump(line) {
 	line = line.replace("[@ui5](https://github.com/ui5)", "@ui5");
 	const moduleMatch = line.match(/Bump (@ui5\/[^\s]+).*to ([^ ]+)/);
 	if (moduleMatch) {
 		const [, moduleName, moduleVersion] = moduleMatch;
-		const moduleDir = path.dirname(require.resolve(`${moduleName}/package.json`));
-		const changelogPath = path.join(moduleDir, "CHANGELOG.md");
+		const changelogPath = fileURLToPath(
+			new URL(`./CHANGELOG.md`, import.meta.resolve(`${moduleName}/package.json`)));
 		const changelog = fs.readFileSync(changelogPath, {
 			encoding: "utf8"
 		});

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Use Node.js LTS 16.18.0
+    - name: Use Node.js LTS 20.11.0
       uses: actions/setup-node@v4.0.2
       with:
-        node-version: 16.18.0
+        node-version: 20.11.0
 
     - name: Install dependencies
       run: npm ci

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,32 +6,35 @@
 trigger:
 - main
 
+variables:
+  CI: true
+
 strategy:
   matrix:
-    linux_node_lts_16:
+    linux_node_lts_20_min_version:
       imageName: 'ubuntu-22.04'
-      node_version: 16.x
-    linux_node_lts_18_min_version:
+      node_version: 20.11.0
+    linux_node_21_min_version:
       imageName: 'ubuntu-22.04'
-      node_version: 18.12.0
-    linux_node_lts_18:
+      node_version: 21.2.0
+    linux_node_lts_20:
       imageName: 'ubuntu-22.04'
-      node_version: 18.x
-    mac_node_lts_18:
+      node_version: 20.x
+    mac_node_lts_20:
       imageName: 'macos-12'
-      node_version: 18.x
-    windows_node_lts_18:
+      node_version: 20.x
+    windows_node_lts_20:
       imageName: 'windows-2022'
-      node_version: 18.x
+      node_version: 20.x
     linux_node_current:
       imageName: 'ubuntu-22.04'
-      node_version: 20.5.x
+      node_version: 21.x
     mac_node_current:
       imageName: 'macos-12'
-      node_version: 20.5.x
+      node_version: 21.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 20.5.x
+      node_version: 21.x
 
 pool:
   vmImage: $(imageName)

--- a/lib/cli/commands/versions.js
+++ b/lib/cli/commands/versions.js
@@ -1,7 +1,7 @@
 import baseMiddleware from "../middlewares/base.js";
 import {createRequire} from "node:module";
 
-// Using CommonsJS require as importing json files causes an ExperimentalWarning
+// Using CommonsJS require since JSON module imports are still experimental
 const require = createRequire(import.meta.url);
 
 const versions = {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -51,8 +51,8 @@
 				"testdouble": "^3.20.1"
 			},
 			"engines": {
-				"node": "^16.18.0 || >=18.12.0",
-				"npm": ">= 8"
+				"node": "^20.11.0 || >=21.2.0",
+				"npm": ">= 10"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
 		"./package.json": "./package.json"
 	},
 	"engines": {
-		"node": "^16.18.0 || >=18.12.0",
-		"npm": ">= 8"
+		"node": "^20.11.0 || >=21.2.0",
+		"npm": ">= 10"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run depcheck && npm run check-licenses",

--- a/test/lib/cli/base.js
+++ b/test/lib/cli/base.js
@@ -6,12 +6,11 @@ import esmock from "esmock";
 import chalk from "chalk";
 import stripAnsi from "strip-ansi";
 import yargs from "yargs";
-import {fileURLToPath} from "node:url";
 import {readFileSync} from "node:fs";
 
 const pkgJsonPath = new URL("../../../package.json", import.meta.url);
 const pkg = JSON.parse(readFileSync(pkgJsonPath));
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const ui5Cli = path.join(__dirname, "..", "..", "..", "bin", "ui5.cjs");
 const ui5 = (args, options = {}) => execa(ui5Cli, args, options);
 

--- a/test/lib/cli/commands/config.js
+++ b/test/lib/cli/commands/config.js
@@ -3,11 +3,10 @@ import sinon from "sinon";
 import esmock from "esmock";
 import chalk from "chalk";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 import {execa} from "execa";
 import stripAnsi from "strip-ansi";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const ui5Cli = path.join(__dirname, "..", "..", "..", "..", "bin", "ui5.cjs");
 const ui5 = (args, options = {}) => execa(ui5Cli, args, options);
 

--- a/test/lib/cli/middlewares/logger.js
+++ b/test/lib/cli/middlewares/logger.js
@@ -91,12 +91,11 @@ test.serial("With log-level, verbose, perf and silent flag", async (t) => {
 
 import path from "node:path";
 import {execa} from "execa";
-import {fileURLToPath} from "node:url";
 import {readFileSync} from "node:fs";
 
 const pkgJsonPath = new URL("../../../../package.json", import.meta.url);
 const pkg = JSON.parse(readFileSync(pkgJsonPath));
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const ui5Cli = path.join(__dirname, "..", "..", "..", "..", "bin", "ui5.cjs");
 const ui5 = (args, options = {}) => execa(ui5Cli, args, options);
 

--- a/test/lib/package-exports.js
+++ b/test/lib/package-exports.js
@@ -10,11 +10,11 @@ test("export of package.json", (t) => {
 });
 
 test("export of bin/ui5.cjs", (t) => {
-	t.truthy(require.resolve("@ui5/cli/bin/ui5.cjs"));
+	t.truthy(import.meta.resolve("@ui5/cli/bin/ui5.cjs"));
 });
 
 test("export of bin/ui5.js (for compatibility with CLI v2 that might invoke a newer local installation", (t) => {
-	t.truthy(require.resolve("@ui5/cli/bin/ui5.js"));
+	t.truthy(import.meta.resolve("@ui5/cli/bin/ui5.js"));
 });
 
 // Check number of definied exports

--- a/test/lib/package-exports.js
+++ b/test/lib/package-exports.js
@@ -1,7 +1,7 @@
 import test from "ava";
 import {createRequire} from "node:module";
 
-// Using CommonsJS require as importing json files causes an ExperimentalWarning
+// Using CommonsJS require since JSON module imports are still experimental
 const require = createRequire(import.meta.url);
 
 // package.json should be exported to allow reading the version


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js and npm releases has been dropped.
Only Node.js 20.11.x and >=21.2.0 as well as npm v10 or higher are supported.

JIRA: CPOUI5FOUNDATION-800