### PR TITLE
[BREAKING] Rename ui5HomeDir to ui5DataDir in APIs

### DIFF
--- a/lib/framework/utils.js
+++ b/lib/framework/utils.js
@@ -37,7 +37,7 @@ export async function createFrameworkResolverInstance({frameworkName, frameworkV
 	return new Resolver({
 		cwd,
 		version: frameworkVersion,
-		ui5HomeDir: await utils.getUi5DataDir({cwd})
+		ui5DataDir: await utils.getUi5DataDir({cwd})
 	});
 }
 
@@ -45,7 +45,7 @@ export async function frameworkResolverResolveVersion({frameworkName, frameworkV
 	const Resolver = await utils.getFrameworkResolver(frameworkName, frameworkVersion);
 	return Resolver.resolveVersion(frameworkVersion, {
 		cwd,
-		ui5HomeDir: await utils.getUi5DataDir({cwd})
+		ui5DataDir: await utils.getUi5DataDir({cwd})
 	});
 }
 

--- a/test/lib/framework/utils.js
+++ b/test/lib/framework/utils.js
@@ -177,7 +177,7 @@ test.serial("createFrameworkResolverInstance: Without ui5DataDir", async (t) => 
 		{
 			cwd: "my-project-path",
 			version: "<framework-version>",
-			ui5HomeDir: undefined
+			ui5DataDir: undefined
 		}
 	]);
 });
@@ -217,7 +217,7 @@ test.serial("createFrameworkResolverInstance: With ui5DataDir", async (t) => {
 		{
 			cwd: "my-project-path",
 			version: "<framework-version>",
-			ui5HomeDir: "my-ui5-data-dir"
+			ui5DataDir: "my-ui5-data-dir"
 		}
 	]);
 });
@@ -246,7 +246,7 @@ test.serial("frameworkResolverResolveVersion", async (t) => {
 		"latest",
 		{
 			cwd: "my-project-path",
-			ui5HomeDir: undefined
+			ui5DataDir: undefined
 		}
 	]);
 });


### PR DESCRIPTION
BREAKING CHANGE:
`@ui5/project`'s Installers' and Resolvers' argument `ui5HomeDir` is now renamed to `ui5DataDir`

JIRA: CPOUI5FOUNDATION-802
Relates to: https://github.com/SAP/ui5-tooling/issues/701
Depends on: https://github.com/SAP/ui5-project/pull/707