### PR TITLE
[INTERNAL] package.json: Allow npm >= v8

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -52,7 +52,7 @@
 			},
 			"engines": {
 				"node": "^20.11.0 || >=21.2.0",
-				"npm": ">= 10"
+				"npm": ">= 8"
 			}
 		},
 		"node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	},
 	"engines": {
 		"node": "^20.11.0 || >=21.2.0",
-		"npm": ">= 10"
+		"npm": ">= 8"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run depcheck && npm run check-licenses",


### PR DESCRIPTION
There is no actual need to increase the minimum npm version. Lockfile v3 is already supported