### PR TITLE
[INTERNAL] Switch back to latest version of update-notifier

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -21,7 +21,7 @@
 				"open": "^10.1.0",
 				"pretty-hrtime": "^1.0.3",
 				"semver": "^7.6.3",
-				"update-notifier": "7.1.0",
+				"update-notifier": "^7.2.0",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -3109,6 +3109,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/atomically": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
+			"integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
+			"dependencies": {
+				"stubborn-fs": "^1.2.5",
+				"when-exit": "^2.1.1"
+			}
+		},
 		"node_modules/ava": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/ava/-/ava-6.1.3.tgz",
@@ -3293,72 +3302,89 @@
 			"license": "ISC"
 		},
 		"node_modules/boxen": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
-			"integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+			"integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-align": "^3.0.1",
-				"camelcase": "^7.0.1",
-				"chalk": "^5.2.0",
+				"camelcase": "^8.0.0",
+				"chalk": "^5.3.0",
 				"cli-boxes": "^3.0.0",
-				"string-width": "^5.1.2",
-				"type-fest": "^2.13.0",
-				"widest-line": "^4.0.1",
-				"wrap-ansi": "^8.1.0"
+				"string-width": "^7.2.0",
+				"type-fest": "^4.21.0",
+				"widest-line": "^5.0.0",
+				"wrap-ansi": "^9.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/boxen/node_modules/camelcase": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-			"integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+			"integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/boxen/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+			"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
 			"license": "MIT"
 		},
 		"node_modules/boxen/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
 			"license": "MIT",
 			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/boxen/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.23.0.tgz",
+			"integrity": "sha512-ZiBujro2ohr5+Z/hZWHESLz3g08BBdrdLMieYFULJO+tWc437sn8kQsWLJoZErY8alNhxre9K4p3GURAG11n+w==",
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
-				"node": ">=12.20"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/boxen/node_modules/wrap-ansi": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+			"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -4300,40 +4326,21 @@
 			"license": "ISC"
 		},
 		"node_modules/configstore": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
-			"integrity": "sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.0.0.tgz",
+			"integrity": "sha512-yk7/5PN5im4qwz0WFZW3PXnzHgPu9mX29Y8uZ3aefe2lBPC1FYttWZRcaW9fKkT0pBCJyuQ2HfbmPVaODi9jcQ==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"dot-prop": "^6.0.1",
-				"graceful-fs": "^4.2.6",
-				"unique-string": "^3.0.0",
-				"write-file-atomic": "^3.0.3",
-				"xdg-basedir": "^5.0.1"
+				"atomically": "^2.0.3",
+				"dot-prop": "^9.0.0",
+				"graceful-fs": "^4.2.11",
+				"xdg-basedir": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/yeoman/configstore?sponsor=1"
-			}
-		},
-		"node_modules/configstore/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"license": "ISC"
-		},
-		"node_modules/configstore/node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
 		"node_modules/console-control-strings": {
@@ -4520,6 +4527,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
 			"integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"type-fest": "^1.0.1"
@@ -4535,6 +4543,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
 			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=10"
@@ -5131,15 +5140,27 @@
 			}
 		},
 		"node_modules/dot-prop": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-			"integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+			"integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
 			"license": "MIT",
 			"dependencies": {
-				"is-obj": "^2.0.0"
+				"type-fest": "^4.18.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/dot-prop/node_modules/type-fest": {
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.23.0.tgz",
+			"integrity": "sha512-ZiBujro2ohr5+Z/hZWHESLz3g08BBdrdLMieYFULJO+tWc437sn8kQsWLJoZErY8alNhxre9K4p3GURAG11n+w==",
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6457,7 +6478,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
 			"integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -7377,9 +7397,9 @@
 			}
 		},
 		"node_modules/is-in-ci": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-0.1.0.tgz",
-			"integrity": "sha512-d9PXLEY0v1iJ64xLiQMJ51J128EYHAaOR4yZqQi8aHGfw6KgifM3/Viw1oZZ1GCVmb3gBuyhLyHj0HgR2DhSXQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+			"integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
 			"license": "MIT",
 			"bin": {
 				"is-in-ci": "cli.js"
@@ -7473,15 +7493,6 @@
 				"lodash.isfinite": "^3.3.2"
 			}
 		},
-		"node_modules/is-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-path-inside": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -7549,6 +7560,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-unicode-supported": {
@@ -12665,6 +12677,11 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
+		"node_modules/stubborn-fs": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
+			"integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g=="
+		},
 		"node_modules/supertap": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/supertap/-/supertap-3.0.1.tgz",
@@ -13253,6 +13270,7 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
 			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-typedarray": "^1.0.0"
@@ -13310,6 +13328,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
 			"integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"crypto-random-string": "^4.0.0"
@@ -13362,21 +13381,21 @@
 			}
 		},
 		"node_modules/update-notifier": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.1.0.tgz",
-			"integrity": "sha512-8SV3rIqVY6EFC1WxH6L0j55s0MO79MFBS1pivmInRJg3pCEDgWHBj1Q6XByTtCLOZIFA0f6zoG9ZWf2Ks9lvTA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.2.0.tgz",
+			"integrity": "sha512-GoBCFKIbF88latQyk8HpHUoJHqZUzYSPI6BySAjs5TWd/TCTMynAsIfGfJ6Ep2DAx6O5YExYGPs3Hdnt2TWdzQ==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"boxen": "^7.1.1",
+				"boxen": "^8.0.0",
 				"chalk": "^5.3.0",
-				"configstore": "^6.0.0",
+				"configstore": "^7.0.0",
 				"import-lazy": "^4.0.0",
-				"is-in-ci": "^0.1.0",
+				"is-in-ci": "^1.0.0",
 				"is-installed-globally": "^1.0.0",
 				"is-npm": "^6.0.0",
 				"latest-version": "^9.0.0",
 				"pupa": "^3.1.0",
-				"semver": "^7.6.2",
+				"semver": "^7.6.3",
 				"semver-diff": "^4.0.0",
 				"xdg-basedir": "^5.1.0"
 			},
@@ -13502,6 +13521,11 @@
 				"webidl-conversions": "^3.0.0"
 			}
 		},
+		"node_modules/when-exit": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.3.tgz",
+			"integrity": "sha512-uVieSTccFIr/SFQdFWN/fFaQYmV37OKtuaGphMAzi4DmmUlrvRBJW5WSLkHyjNQY/ePJMz3LoiX9R3yy1Su6Hw=="
+		},
 		"node_modules/which": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -13535,38 +13559,38 @@
 			}
 		},
 		"node_modules/widest-line": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
-			"integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+			"integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
 			"license": "MIT",
 			"dependencies": {
-				"string-width": "^5.0.1"
+				"string-width": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/widest-line/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+			"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
 			"license": "MIT"
 		},
 		"node_modules/widest-line/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
 			"license": "MIT",
 			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -128,10 +128,11 @@
 		"open": "^10.1.0",
 		"pretty-hrtime": "^1.0.3",
 		"semver": "^7.6.3",
-		"update-notifier": "7.1.0",
+		"update-notifier": "^7.2.0",
 		"yargs": "^17.7.2"
 	},
 	"devDependencies": {
+		"@eslint/js": "^9.8.0",
 		"@istanbuljs/esm-loader-hook": "^0.2.0",
 		"ava": "^6.1.3",
 		"chokidar-cli": "^3.0.0",
@@ -139,7 +140,6 @@
 		"depcheck": "^1.4.7",
 		"docdash": "^2.0.2",
 		"eslint": "^9.8.0",
-		"@eslint/js": "^9.8.0",
 		"eslint-config-google": "^0.14.0",
 		"eslint-plugin-ava": "^15.0.1",
 		"eslint-plugin-jsdoc": "^48.11.0",


### PR DESCRIPTION
Follow-up of https://github.com/SAP/ui5-cli/pull/731

The problematic dependency is not used anymore by the "boxen" package.