### PR TITLE
[INTERNAL] versions: Include package location in verbose mode

### DIFF
--- a/lib/cli/commands/versions.js
+++ b/lib/cli/commands/versions.js
@@ -1,4 +1,6 @@
 import baseMiddleware from "../middlewares/base.js";
+import path from "node:path";
+import {isLogLevelEnabled} from "@ui5/logger";
 import {createRequire} from "node:module";
 
 // Using CommonsJS require since JSON module imports are still experimental
@@ -14,7 +16,15 @@ const NOT_FOUND = "===(not installed)";
 versions.getVersion = (pkg) => {
 	try {
 		const packageInfo = require(`${pkg}/package.json`);
-		return packageInfo.version || NOT_FOUND;
+		if (!packageInfo?.version) {
+			return NOT_FOUND;
+		}
+		let res = packageInfo.version;
+		if (isLogLevelEnabled("verbose")) {
+			const packageDir = path.dirname(require.resolve(`${pkg}/package.json`));
+			res += ` (from ${packageDir})`;
+		}
+		return res;
 	} catch {
 		return NOT_FOUND;
 	}

--- a/test/lib/cli/commands/versions.js
+++ b/test/lib/cli/commands/versions.js
@@ -1,6 +1,8 @@
 import test from "ava";
 import sinon from "sinon";
+import path from "node:path";
 import versions from "../../../../lib/cli/commands/versions.js";
+const __dirname = path.join(import.meta.dirname, "..");
 
 test.afterEach.always((t) => {
 	sinon.restore();
@@ -18,6 +20,31 @@ test.serial("Retrieves version from package.json", (t) => {
 	t.is(fsVersion, "0.2.0", "retrieved correct version for fs");
 	t.is(projectVersion, "0.2.3", "retrieved correct version for project");
 	t.is(loggerVersion, "0.2.2", "retrieved correct version for logger");
+});
+
+test.serial("Retrieves version and package path in verbose mode", async (t) => {
+	const {setLogLevel} = await import("@ui5/logger");
+	setLogLevel("verbose");
+	const builderPath = "../../../test/fixtures/@ui5/builder";
+	const builderVersion = versions.getVersion(builderPath);
+	const serverPath = "../../../test/fixtures/@ui5/server";
+	const serverVersion = versions.getVersion(serverPath);
+	const fsPath = "../../../test/fixtures/@ui5/fs";
+	const fsVersion = versions.getVersion(fsPath);
+	const projectPath = "../../../test/fixtures/@ui5/project";
+	const projectVersion = versions.getVersion(projectPath);
+	const loggerPath = "../../../test/fixtures/@ui5/logger";
+	const loggerVersion = versions.getVersion(loggerPath);
+	t.is(builderVersion, `0.2.6 (from ${path.resolve(__dirname, builderPath)})`,
+		"retrieved correct version and path for builder");
+	t.is(serverVersion, `0.2.2 (from ${path.resolve(__dirname, serverPath)})`,
+		"retrieved correct version and path for server");
+	t.is(fsVersion, `0.2.0 (from ${path.resolve(__dirname, fsPath)})`,
+		"retrieved correct version and path for fs");
+	t.is(projectVersion, `0.2.3 (from ${path.resolve(__dirname, projectPath)})`,
+		"retrieved correct version and path for project");
+	t.is(loggerVersion, `0.2.2 (from ${path.resolve(__dirname, loggerPath)})`,
+		"retrieved correct version and path for logger");
 });
 
 test.serial("Error: returns not installed if version was not found", (t) => {


### PR DESCRIPTION
If verbose logging is enabled, also show the local  path of each
UI5 Tooling module. This can be helpful to debug dev environment issues.