### PR TITLE
[FIX] serve: Respect `--config` option with `--dependency-definition`

### DIFF
--- a/lib/cli/commands/serve.js
+++ b/lib/cli/commands/serve.js
@@ -93,6 +93,7 @@ serve.handler = async function(argv) {
 	if (argv.dependencyDefinition) {
 		graph = await graphFromStaticFile({
 			filePath: argv.dependencyDefinition,
+			rootConfigPath: argv.config,
 			versionOverride: argv.frameworkVersion,
 			cacheMode: argv.cacheMode,
 		});

--- a/test/lib/cli/commands/serve.js
+++ b/test/lib/cli/commands/serve.js
@@ -344,7 +344,46 @@ test.serial("ui5 serve --dependency-definition", async (t) => {
 	t.is(graph.graphFromStaticFile.callCount, 1);
 	t.deepEqual(graph.graphFromStaticFile.getCall(0).args, [{
 		filePath: fakePath, versionOverride: undefined,
-		cacheMode: "Default",
+		cacheMode: "Default", rootConfigPath: undefined
+	}]);
+
+	t.is(t.context.consoleOutput, `Server started
+URL: http://localhost:8080
+`);
+
+	t.is(server.serve.callCount, 1);
+	t.deepEqual(server.serve.getCall(0).args, [
+		fakeGraph,
+		{
+			acceptRemoteConnections: false,
+			cert: undefined,
+			changePortIfInUse: true,
+			h2: false,
+			key: undefined,
+			port: 8080,
+			sendSAPTargetCSP: false,
+			serveCSPReports: false,
+			simpleIndex: false
+		}
+	]);
+});
+
+test.serial("ui5 serve --dependency-definition / --config", async (t) => {
+	const {argv, serve, graph, server, fakeGraph} = t.context;
+
+	const fakeDependenciesPath = path.join("/", "path", "to", "dependencies.yaml");
+	argv.dependencyDefinition = fakeDependenciesPath;
+
+	const fakeConfigPath = path.join("/", "path", "to", "ui5.yaml");
+	argv.config = fakeConfigPath;
+
+	await serve.handler(argv);
+
+	t.is(graph.graphFromPackageDependencies.callCount, 0);
+	t.is(graph.graphFromStaticFile.callCount, 1);
+	t.deepEqual(graph.graphFromStaticFile.getCall(0).args, [{
+		filePath: fakeDependenciesPath, versionOverride: undefined,
+		cacheMode: "Default", rootConfigPath: fakeConfigPath
 	}]);
 
 	t.is(t.context.consoleOutput, `Server started


### PR DESCRIPTION
Previously, the `--config` option was not respected when using the `--dependency-definition` option with the `serve` command.

This change ensures consistent behavior with the `build` command, where the `--config` option is already handled correctly.
