### PR TITLE
[INTERNAL] licensee: Add exception for 'stubborn-utils'

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -9,7 +9,8 @@
 	},
 	"packages": {
 		"callsite": "1.0.0",
-		"yesno": "0.4.0"
+		"yesno": "0.4.0",
+		"stubborn-utils": "1.0.1"
 	},
 	"corrections": true
 }


### PR DESCRIPTION
New transitive dependency [stubborn-utils](https://www.npmjs.com/package/stubborn-utils) is licensed under MIT but missing the package.json entry

Related: https://github.com/SAP/ui5-cli/pull/730