### PR TITLE
[INTERNAL] Pin eslint-plugin-jsdoc to 61.5.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -38,7 +38,7 @@
 				"eslint": "^9.39.2",
 				"eslint-config-google": "^0.14.0",
 				"eslint-plugin-ava": "^15.1.0",
-				"eslint-plugin-jsdoc": "^61.7.1",
+				"eslint-plugin-jsdoc": "61.5.0",
 				"esmock": "^2.7.3",
 				"execa": "^9.6.1",
 				"globals": "^16.5.0",
@@ -545,17 +545,16 @@
 			"license": "CC0-1.0"
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.78.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.78.0.tgz",
-			"integrity": "sha512-rQkU5u8hNAq2NVRzHnIUUvR6arbO0b6AOlvpTNS48CkiKSn/xtNfOzBK23JE4SiW89DgvU7GtxLVgV4Vn2HBAw==",
+			"version": "0.76.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.76.0.tgz",
+			"integrity": "sha512-g+RihtzFgGTx2WYCuTHbdOXJeAlGnROws0TeALx9ow/ZmOROOZkVg5wp/B44n0WJgI4SQFP1eWM2iRPlU2Y14w==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.8",
-				"@typescript-eslint/types": "^8.46.4",
+				"@typescript-eslint/types": "^8.46.0",
 				"comment-parser": "1.4.1",
 				"esquery": "^1.6.0",
-				"jsdoc-type-pratt-parser": "~7.0.0"
+				"jsdoc-type-pratt-parser": "~6.10.0"
 			},
 			"engines": {
 				"node": ">=20.11.0"
@@ -566,7 +565,6 @@
 			"resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
 			"integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -2728,7 +2726,6 @@
 			"resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
 			"integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -2904,7 +2901,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.1.tgz",
 			"integrity": "sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -4723,7 +4719,6 @@
 			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
 			"integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">= 12.0.0"
 			}
@@ -6039,20 +6034,19 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "61.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-61.7.1.tgz",
-			"integrity": "sha512-36DpldF95MlTX//n3/naULFVt8d1cV4jmSkx7ZKrE9ikkKHAgMLesuWp1SmwpVwAs5ndIM6abKd6PeOYZUgdWg==",
+			"version": "61.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-61.5.0.tgz",
+			"integrity": "sha512-PR81eOGq4S7diVnV9xzFSBE4CDENRQGP0Lckkek8AdHtbj+6Bm0cItwlFnxsLFriJHspiE3mpu8U20eODyToIg==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.78.0",
+				"@es-joy/jsdoccomment": "~0.76.0",
 				"@es-joy/resolve.exports": "1.2.0",
 				"are-docs-informative": "^0.0.2",
 				"comment-parser": "1.4.1",
 				"debug": "^4.4.3",
 				"escape-string-regexp": "^4.0.0",
-				"espree": "^11.0.0",
-				"esquery": "^1.7.0",
+				"espree": "^10.4.0",
+				"esquery": "^1.6.0",
 				"html-entities": "^2.6.0",
 				"object-deep-merge": "^2.0.0",
 				"parse-imports-exports": "^0.2.4",
@@ -6078,37 +6072,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-			"integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/espree": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-11.1.0.tgz",
-			"integrity": "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"acorn": "^8.15.0",
-				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^5.0.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=24"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -8380,11 +8343,10 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.0.0.tgz",
-			"integrity": "sha512-c7YbokssPOSHmqTbSAmTtnVgAVa/7lumWNYqomgd5KOMyPrRve2anx6lonfOsXEQacqF9FKVUj7bLg4vRSvdYA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.10.0.tgz",
+			"integrity": "sha512-+LexoTRyYui5iOhJGn13N9ZazL23nAHGkXsa1p/C8yeq79WRfLBag6ZZ0FQG2aRoc9yfo59JT9EYCQonOkHKkQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=20.0.0"
 			}
@@ -10339,8 +10301,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
 			"integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
@@ -11989,7 +11950,6 @@
 			"resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
 			"integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -13558,7 +13518,6 @@
 			"resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
 			"integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/base62": "^1.0.0",
 				"reserved-identifiers": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
 		"eslint": "^9.39.2",
 		"eslint-config-google": "^0.14.0",
 		"eslint-plugin-ava": "^15.1.0",
-		"eslint-plugin-jsdoc": "^61.7.1",
+		"eslint-plugin-jsdoc": "61.5.0",
 		"esmock": "^2.7.3",
 		"execa": "^9.6.1",
 		"globals": "^16.5.0",


### PR DESCRIPTION
Higher versions require a slightly higher Node.js version (20.19.0) than currently required by this project (20.11.0)

