### PR TITLE
[DEPENDENCY] Bump tar from 6.2.1 to 7.5.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1153,23 +1153,6 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/@npmcli/agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
-			"integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/@npmcli/git": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.8.tgz",
@@ -1249,100 +1232,6 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/@sigstore/bundle": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.2.tgz",
-			"integrity": "sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.3.2"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/@sigstore/core": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@sigstore/core/-/core-1.1.0.tgz",
-			"integrity": "sha512-JzBqdVIyqm2FRQCulY6nbQzMpJJpSiJ8XXWMhtOX9eKgaXXpfNOF53lzQEjIydlStnd/eFtuC1dW4VYdD93oRg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/@sigstore/protobuf-specs": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.3.tgz",
-			"integrity": "sha512-RpacQhBlwpBWd7KEJsRKcBQalbV28fvkxwTOJIqhIuDysMMaJW47V4OqW30iJB9uRpqOSxxEAQFdr8tTattReQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/@sigstore/sign": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.2.tgz",
-			"integrity": "sha512-5Vz5dPVuunIIvC5vBb0APwo7qKA4G9yM48kPWJT+OEERs40md5GoUR1yedwpekWZ4m0Hhw44m6zU+ObsON+iDA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"make-fetch-happen": "^13.0.1",
-				"proc-log": "^4.2.0",
-				"promise-retry": "^2.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/@sigstore/tuf": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.3.4.tgz",
-			"integrity": "sha512-44vtsveTPUpqhm9NCrbU8CWLe3Vck2HO1PNLw7RIajbB7xhtn5RBPm1VNSCMwqGYHhDsBJG8gDF0q4lgydsJvw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"tuf-js": "^2.2.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/@sigstore/verify": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-1.2.1.tgz",
-			"integrity": "sha512-8iKx79/F73DKbGfRf7+t4dqrc0bRr0thdPrxAtCKWRm/F0tG71i6O1rvlnScncJLLBZHn3h8M3c1BSUAb9yu8g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.1.0",
-				"@sigstore/protobuf-specs": "^0.3.2"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/@tufjs/models": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.1.tgz",
-			"integrity": "sha512-92F7/SFyufn4DXsha9+QfKnN03JGqtMFMXgSHbZOo8JG59WkTni7UzAouNQDf7AuP9OAMxVOPQcqG3sB7w+kkg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/canonical-json": "2.0.0",
-				"minimatch": "^9.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/abbrev": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -1363,16 +1252,6 @@
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/hosted-git-info": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -1384,19 +1263,6 @@
 			},
 			"engines": {
 				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/ignore-walk": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.5.tgz",
-			"integrity": "sha512-VuuG0wCnjhnylG1ABXT3dAuIpTNDs/G8jlpmwXY03fXoXy/8ZK8/T+hMzt8L4WnrLCJgdybqgPagnF/f97cg3A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minimatch": "^9.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/ini": {
@@ -1426,30 +1292,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/@npmcli/arborist/node_modules/make-fetch-happen": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
-			"integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/agent": "^2.0.0",
-				"cacache": "^18.0.0",
-				"http-cache-semantics": "^4.1.1",
-				"is-lambda": "^1.0.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.3",
-				"proc-log": "^4.2.0",
-				"promise-retry": "^2.0.1",
-				"ssri": "^10.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/minimatch": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -1466,51 +1308,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/minipass-fetch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
-			"integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.1.2"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/nopt": {
 			"version": "7.2.1",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
@@ -1522,19 +1319,6 @@
 			},
 			"bin": {
 				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/npm-packlist": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
-			"integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"ignore-walk": "^6.0.4"
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -1556,38 +1340,6 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@npmcli/arborist/node_modules/pacote": {
-			"version": "18.0.6",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-18.0.6.tgz",
-			"integrity": "sha512-+eK3G27SMwsB8kLIuj4h1FUhHtwiEUo21Tw8wNjmvdlpOEr613edv+8FUsTj/4F/VN5ywGE19X18N7CC2EJk6A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/git": "^5.0.0",
-				"@npmcli/installed-package-contents": "^2.0.1",
-				"@npmcli/package-json": "^5.1.0",
-				"@npmcli/promise-spawn": "^7.0.0",
-				"@npmcli/run-script": "^8.0.0",
-				"cacache": "^18.0.0",
-				"fs-minipass": "^3.0.0",
-				"minipass": "^7.0.2",
-				"npm-package-arg": "^11.0.0",
-				"npm-packlist": "^8.0.0",
-				"npm-pick-manifest": "^9.0.0",
-				"npm-registry-fetch": "^17.0.0",
-				"proc-log": "^4.0.0",
-				"promise-retry": "^2.0.1",
-				"sigstore": "^2.2.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11"
-			},
-			"bin": {
-				"pacote": "bin/index.js"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@npmcli/arborist/node_modules/proc-log": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
@@ -1596,94 +1348,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/sigstore": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.3.1.tgz",
-			"integrity": "sha512-8G+/XDU8wNsJOQS5ysDVO0Etg9/2uA5gR9l4ZwijjlwxBcrU6RPfwi2+jJmbP+Ap1Hlp/nVAaEO4Fj22/SL2gQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"@sigstore/sign": "^2.3.2",
-				"@sigstore/tuf": "^2.3.4",
-				"@sigstore/verify": "^1.2.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/tar/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/tuf-js": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.1.tgz",
-			"integrity": "sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/models": "2.0.1",
-				"debug": "^4.3.4",
-				"make-fetch-happen": "^13.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@npmcli/arborist/node_modules/which": {
@@ -1701,13 +1365,6 @@
 			"engines": {
 				"node": "^16.13.0 || >=18.0.0"
 			}
-		},
-		"node_modules/@npmcli/arborist/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/@npmcli/config": {
 			"version": "9.0.0",
@@ -1839,226 +1496,6 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@npmcli/agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
-			"integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@npmcli/git": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.8.tgz",
-			"integrity": "sha512-liASfw5cqhjNW9UFd+ruwwdEf/lbOAQjLL2XY2dFW/bkJheXDYZgOyul/4gVvEV4BWkTXjYGmDqMw9uegdbJNQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/promise-spawn": "^7.0.0",
-				"ini": "^4.1.3",
-				"lru-cache": "^10.0.1",
-				"npm-pick-manifest": "^9.0.0",
-				"proc-log": "^4.0.0",
-				"promise-inflight": "^1.0.1",
-				"promise-retry": "^2.0.1",
-				"semver": "^7.3.5",
-				"which": "^4.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@npmcli/package-json": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.2.1.tgz",
-			"integrity": "sha512-f7zYC6kQautXHvNbLEWgD/uGu1+xCn9izgqBfgItWSx22U0ZDekxN08A1vM8cTxj/cRVe0Q94Ode+tdoYmIOOQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/git": "^5.0.0",
-				"glob": "^10.2.2",
-				"hosted-git-info": "^7.0.0",
-				"json-parse-even-better-errors": "^3.0.0",
-				"normalize-package-data": "^6.0.0",
-				"proc-log": "^4.0.0",
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@npmcli/promise-spawn": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
-			"integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"which": "^4.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@sigstore/bundle": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.2.tgz",
-			"integrity": "sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.3.2"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@sigstore/core": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@sigstore/core/-/core-1.1.0.tgz",
-			"integrity": "sha512-JzBqdVIyqm2FRQCulY6nbQzMpJJpSiJ8XXWMhtOX9eKgaXXpfNOF53lzQEjIydlStnd/eFtuC1dW4VYdD93oRg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@sigstore/protobuf-specs": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.3.tgz",
-			"integrity": "sha512-RpacQhBlwpBWd7KEJsRKcBQalbV28fvkxwTOJIqhIuDysMMaJW47V4OqW30iJB9uRpqOSxxEAQFdr8tTattReQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@sigstore/sign": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.2.tgz",
-			"integrity": "sha512-5Vz5dPVuunIIvC5vBb0APwo7qKA4G9yM48kPWJT+OEERs40md5GoUR1yedwpekWZ4m0Hhw44m6zU+ObsON+iDA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"make-fetch-happen": "^13.0.1",
-				"proc-log": "^4.2.0",
-				"promise-retry": "^2.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@sigstore/tuf": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.3.4.tgz",
-			"integrity": "sha512-44vtsveTPUpqhm9NCrbU8CWLe3Vck2HO1PNLw7RIajbB7xhtn5RBPm1VNSCMwqGYHhDsBJG8gDF0q4lgydsJvw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"tuf-js": "^2.2.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@sigstore/verify": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-1.2.1.tgz",
-			"integrity": "sha512-8iKx79/F73DKbGfRf7+t4dqrc0bRr0thdPrxAtCKWRm/F0tG71i6O1rvlnScncJLLBZHn3h8M3c1BSUAb9yu8g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.1.0",
-				"@sigstore/protobuf-specs": "^0.3.2"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/@tufjs/models": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.1.tgz",
-			"integrity": "sha512-92F7/SFyufn4DXsha9+QfKnN03JGqtMFMXgSHbZOo8JG59WkTni7UzAouNQDf7AuP9OAMxVOPQcqG3sB7w+kkg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/canonical-json": "2.0.0",
-				"minimatch": "^9.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/ignore-walk": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.5.tgz",
-			"integrity": "sha512-VuuG0wCnjhnylG1ABXT3dAuIpTNDs/G8jlpmwXY03fXoXy/8ZK8/T+hMzt8L4WnrLCJgdybqgPagnF/f97cg3A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minimatch": "^9.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/ini": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-			"integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@npmcli/metavuln-calculator/node_modules/json-parse-even-better-errors": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
@@ -2067,159 +1504,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/make-fetch-happen": {
-			"version": "13.0.1",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
-			"integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/agent": "^2.0.0",
-				"cacache": "^18.0.0",
-				"http-cache-semantics": "^4.1.1",
-				"is-lambda": "^1.0.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.3",
-				"proc-log": "^4.2.0",
-				"promise-retry": "^2.0.1",
-				"ssri": "^10.0.0"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/minipass-fetch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
-			"integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.1.2"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/npm-packlist": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
-			"integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"ignore-walk": "^6.0.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/npm-pick-manifest": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz",
-			"integrity": "sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-install-checks": "^6.0.0",
-				"npm-normalize-package-bin": "^3.0.0",
-				"npm-package-arg": "^11.0.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
-			"version": "18.0.6",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-18.0.6.tgz",
-			"integrity": "sha512-+eK3G27SMwsB8kLIuj4h1FUhHtwiEUo21Tw8wNjmvdlpOEr613edv+8FUsTj/4F/VN5ywGE19X18N7CC2EJk6A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/git": "^5.0.0",
-				"@npmcli/installed-package-contents": "^2.0.1",
-				"@npmcli/package-json": "^5.1.0",
-				"@npmcli/promise-spawn": "^7.0.0",
-				"@npmcli/run-script": "^8.0.0",
-				"cacache": "^18.0.0",
-				"fs-minipass": "^3.0.0",
-				"minipass": "^7.0.2",
-				"npm-package-arg": "^11.0.0",
-				"npm-packlist": "^8.0.0",
-				"npm-pick-manifest": "^9.0.0",
-				"npm-registry-fetch": "^17.0.0",
-				"proc-log": "^4.0.0",
-				"promise-retry": "^2.0.1",
-				"sigstore": "^2.2.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11"
-			},
-			"bin": {
-				"pacote": "bin/index.js"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@npmcli/metavuln-calculator/node_modules/proc-log": {
@@ -2231,117 +1515,6 @@
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/sigstore": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.3.1.tgz",
-			"integrity": "sha512-8G+/XDU8wNsJOQS5ysDVO0Etg9/2uA5gR9l4ZwijjlwxBcrU6RPfwi2+jJmbP+Ap1Hlp/nVAaEO4Fj22/SL2gQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^2.3.2",
-				"@sigstore/core": "^1.0.0",
-				"@sigstore/protobuf-specs": "^0.3.2",
-				"@sigstore/sign": "^2.3.2",
-				"@sigstore/tuf": "^2.3.4",
-				"@sigstore/verify": "^1.2.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/tar/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/tuf-js": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.1.tgz",
-			"integrity": "sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/models": "2.0.1",
-				"debug": "^4.3.4",
-				"make-fetch-happen": "^13.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/which": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-			"integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/metavuln-calculator/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/@npmcli/name-from-folder": {
 			"version": "3.0.0",
@@ -3913,49 +3086,12 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/cacache/node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/cacache/node_modules/lru-cache": {
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/cacache/node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/cacache/node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/cacache/node_modules/p-map": {
 			"version": "4.0.0",
@@ -3972,68 +3108,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/cacache/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/cacache/node_modules/tar/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/cacache/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cacache/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cacache/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/caching-transform": {
 			"version": "4.0.0",
@@ -9408,42 +8482,6 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/node-gyp/node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-gyp/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/node-gyp/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/node-gyp/node_modules/lru-cache": {
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -9544,35 +8582,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/node-gyp/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-gyp/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/node-gyp/node_modules/which": {
@@ -10645,31 +9654,6 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/pacote/node_modules/cacache/node_modules/tar": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-			"integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/pacote/node_modules/cacache/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/pacote/node_modules/lru-cache": {
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -10698,31 +9682,6 @@
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/pacote/node_modules/node-gyp/node_modules/tar": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-			"integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/pacote/node_modules/node-gyp/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/pacote/node_modules/npm-bundled": {
@@ -10792,91 +9751,6 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/pacote/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me",
-			"license": "ISC",
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/pacote/node_modules/tar/node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/pacote/node_modules/tar/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/pacote/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pacote/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/pacote/node_modules/tar/node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/pacote/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/pacote/node_modules/unique-filename": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
@@ -10909,12 +9783,6 @@
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
 			}
-		},
-		"node_modules/pacote/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"license": "ISC"
 		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -155,5 +155,16 @@
 		"strip-ansi": "^7.1.2",
 		"tap-xunit": "^2.4.1",
 		"testdouble": "^3.20.2"
+	},
+	"overrides": {
+		"pacote@<=20": {
+			"tar": "^7.5.6"
+		},
+		"cacache@18": {
+			"tar": "^7.5.6"
+		},
+		"node-gyp@10": {
+			"tar": "^7.5.6"
+		}
 	}
 }


### PR DESCRIPTION
Resolves alerts for several security advisories such as: https://github.com/isaacs/node-tar/security/advisories/GHSA-r6q2-hw4h-h46w https://github.com/isaacs/node-tar/security/advisories/GHSA-8qq5-rm4j-mr97

As per our assessment those vulnerabilities are not exploitable in the context of UI5 CLI.

The override for tar is specifically defined where necessary in order to not downgrade tar in case a new major version is being used by other dependencies.
