### PR TITLE
[INTERNAL] Bump qs to 6.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6986,23 +6986,6 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
-		"node_modules/express/node_modules/qs": {
-			"version": "6.15.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-			"inBundle": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"es-define-property": "^1.0.1",
-				"side-channel": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/express/node_modules/raw-body": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,16 @@
 		"type": "git",
 		"url": "git@github.com:SAP/ui5-cli.git"
 	},
+	"overrides": {
+		"@ui5/server": {
+			"qs": "^6.16.0",
+			"express": {
+				"body-parser@1.20.6": {
+					"qs": "^6.16.0"
+				}
+			}
+		}
+	},
 	"dependencies": {
 		"@ui5/builder": "^4.3.1",
 		"@ui5/fs": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -130,13 +130,11 @@
 		"url": "git@github.com:SAP/ui5-cli.git"
 	},
 	"overrides": {
-		"@ui5/server": {
-			"qs": "^6.16.0",
-			"express": {
-				"body-parser@1.20.6": {
-					"qs": "^6.16.0"
-				}
-			}
+		"express@4": {
+			"body-parser@1.20.6": {
+				"qs": "^6.16.0"
+			},
+			"qs": "^6.16.0"
 		}
 	},
 	"dependencies": {


### PR DESCRIPTION
Bump qs to a non vulenrable version and enforce overrides for it.

Resolves GHSA-x5fp-wj9c-mxmx & GHSA-4mjr-xmp4-gh2g