### PR TITLE
[FIX] Remove qs overrides from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6986,6 +6986,23 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
+		"node_modules/express/node_modules/qs": {
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/express/node_modules/raw-body": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -129,14 +129,6 @@
 		"type": "git",
 		"url": "git@github.com:SAP/ui5-cli.git"
 	},
-	"overrides": {
-		"express@4": {
-			"body-parser@1.20.6": {
-				"qs": "^6.16.0"
-			},
-			"qs": "^6.16.0"
-		}
-	},
 	"dependencies": {
 		"@ui5/builder": "^4.3.1",
 		"@ui5/fs": "^4.0.6",


### PR DESCRIPTION
Consumers who installed @ui5/cli and ran "npm ci" got:

  `npm error Missing: qs@6.15.3 from lock file`

The "overrides" entry forced a single qs@6.16.0 across the bundled express/body-parser tree at pack time. Overrides are producer-only, so consumers re-resolve without them, expect qs@6.15.3, and the lockfile no longer matches, breaking "npm ci".

The GHSA-x5fp-wj9c-mxmx / GHSA-4mjr-xmp4-gh2g qs vulnerability that the override addressed is not applicable to the way express / body-parser use qs, so removing the override does not expose us to it.

Upstream fixes are in progress but not yet consumable: the qs bumps are still open pull requests, not merged or released, so we cannot rely on the transitive dependencies alone yet:

  https://github.com/expressjs/express/pull/7440
  https://github.com/expressjs/body-parser/pull/761

Dropping the override lets qs resolve naturally and keeps package.json and package-lock.json in sync.
